### PR TITLE
Access External Storage Sources

### DIFF
--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/tv/folderpicker/TVFolderPickerActivity.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/tv/folderpicker/TVFolderPickerActivity.kt
@@ -60,7 +60,7 @@ class TVFolderPickerActivity : BaseTVActivity() {
         override fun onCreateActions(actions: MutableList<GuidedAction>, savedInstanceState: Bundle?) {
             super.onCreateActions(actions, savedInstanceState)
 
-            if(directory.parent != null)
+            if (directory.parent != null)
                 addAction(actions, ACTION_NAVIGATE, "Parent Directory", directory.parent)
 
             directory.listFiles()

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/tv/folderpicker/TVFolderPickerActivity.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/tv/folderpicker/TVFolderPickerActivity.kt
@@ -60,6 +60,9 @@ class TVFolderPickerActivity : BaseTVActivity() {
         override fun onCreateActions(actions: MutableList<GuidedAction>, savedInstanceState: Bundle?) {
             super.onCreateActions(actions, savedInstanceState)
 
+            if(directory.parent != null)
+                addAction(actions, ACTION_NAVIGATE, "Parent Directory", directory.parent)
+
             directory.listFiles()
                 ?.filter { it.isDirectory }
                 ?.forEach {


### PR DESCRIPTION
Added parent directory option to folder selection for Android TV. This allows the user to go back to the /storage directory and access other storage sources. [#83] 