### PR TITLE
Do not trust Android gamepad port assignments. 

### DIFF
--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/LemuroidApplicationModule.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/LemuroidApplicationModule.kt
@@ -29,7 +29,6 @@ import com.swordfish.lemuroid.app.mobile.feature.gamemenu.GameMenuActivity
 import com.swordfish.lemuroid.app.mobile.feature.main.MainActivity
 import com.swordfish.lemuroid.app.mobile.feature.settings.SettingsManager
 import com.swordfish.lemuroid.app.shared.settings.BiosPreferences
-import com.swordfish.lemuroid.app.shared.settings.GamePadBindingsPreferences
 import com.swordfish.lemuroid.app.shared.settings.GamePadManager
 import com.swordfish.lemuroid.lib.core.CoreManager
 import com.swordfish.lemuroid.lib.core.CoreVariablesManager
@@ -262,13 +261,6 @@ abstract class LemuroidApplicationModule {
         @PerApp
         @JvmStatic
         fun gamepadsManager(context: Context) = GamePadManager(context)
-
-        @Provides
-        @PerApp
-        @JvmStatic
-        fun gamepadBindingsManager(gamePadManager: GamePadManager) = GamePadBindingsPreferences(
-            gamePadManager
-        )
 
         @Provides
         @PerApp

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/game/GameActivity.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/game/GameActivity.kt
@@ -106,7 +106,10 @@ class GameActivity : BaseGameActivity() {
             .getGamePadsObservable()
             .map { it.size }
             .autoDispose(scope())
-            .subscribeBy(Timber::e) { overlayLayout.setVisibleOrGone(it == 0) }
+            .subscribeBy(Timber::e) {
+                val displayVirtualKeys = !settingsManager.hideTouchControlsWhileGamePad || it == 0
+                overlayLayout.setVisibleOrGone(displayVirtualKeys)
+            }
     }
 
     private fun handleGamePadGesture(it: Event.Gesture) {

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/main/MainActivity.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/main/MainActivity.kt
@@ -24,6 +24,8 @@ import com.swordfish.lemuroid.app.mobile.feature.favorites.FavoritesFragment
 import com.swordfish.lemuroid.app.mobile.feature.settings.BiosSettingsFragment
 import com.swordfish.lemuroid.app.mobile.feature.settings.GamepadSettingsFragment
 import com.swordfish.lemuroid.app.shared.game.GameLauncherActivity
+import com.swordfish.lemuroid.app.shared.settings.GamePadSettingsPreferences
+import com.swordfish.lemuroid.app.shared.settings.GamePadManager
 import com.swordfish.lemuroid.app.shared.settings.SettingsInteractor
 import com.swordfish.lemuroid.ext.feature.review.ReviewManager
 import com.swordfish.lemuroid.lib.ui.setVisibleOrGone
@@ -143,6 +145,12 @@ class MainActivity : RetrogradeAppCompatActivity() {
             @JvmStatic
             fun gameInteractor(activity: MainActivity, retrogradeDb: RetrogradeDatabase) =
                 GameInteractor(activity, retrogradeDb, false)
+
+            @Provides
+            @PerActivity
+            @JvmStatic
+            fun gamepadSettingsPreferences(gamePadManager: GamePadManager) =
+                GamePadSettingsPreferences(gamePadManager, false)
         }
     }
 }

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/settings/GamepadSettingsFragment.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/settings/GamepadSettingsFragment.kt
@@ -5,7 +5,7 @@ import android.os.Bundle
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import com.swordfish.lemuroid.R
-import com.swordfish.lemuroid.app.shared.settings.GamePadBindingsPreferences
+import com.swordfish.lemuroid.app.shared.settings.GamePadSettingsPreferences
 import com.swordfish.lemuroid.app.shared.settings.GamePadManager
 import com.uber.autodispose.android.lifecycle.scope
 import com.uber.autodispose.autoDispose
@@ -15,7 +15,7 @@ import javax.inject.Inject
 
 class GamepadSettingsFragment : PreferenceFragmentCompat() {
 
-    @Inject lateinit var gamePadBindingsPreferences: GamePadBindingsPreferences
+    @Inject lateinit var gamePadSettingsPreferences: GamePadSettingsPreferences
     @Inject lateinit var gamePadManager: GamePadManager
 
     override fun onAttach(context: Context) {
@@ -34,7 +34,7 @@ class GamepadSettingsFragment : PreferenceFragmentCompat() {
 
     private fun refreshBindings() {
         preferenceScreen.removeAll()
-        gamePadBindingsPreferences.addGamePadsPreferencesToScreen(requireContext(), preferenceScreen)
+        gamePadSettingsPreferences.addGamePadsPreferencesToScreen(requireContext(), preferenceScreen)
     }
 
     override fun onPreferenceTreeClick(preference: Preference): Boolean {
@@ -45,7 +45,7 @@ class GamepadSettingsFragment : PreferenceFragmentCompat() {
     }
 
     private fun handleResetBindings() {
-        gamePadBindingsPreferences.resetAllBindings()
+        gamePadSettingsPreferences.resetAllBindings()
             .observeOn(AndroidSchedulers.mainThread())
             .autoDispose(scope())
             .subscribe { refreshBindings() }

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/settings/SettingsManager.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/settings/SettingsManager.kt
@@ -35,4 +35,10 @@ class SettingsManager(private val context: Context) {
         getString(R.string.pref_key_tilt_sensitivity_index),
         defaultIndex = 6
     )
+
+    var hideTouchControlsWhileGamePad: Boolean by SharedPreferencesDelegates.BooleanDelegate(
+        sharedPreferences,
+        getString(R.string.pref_key_allow_hide_touch_controls),
+        true
+    )
 }

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/game/BaseGameActivity.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/game/BaseGameActivity.kt
@@ -328,19 +328,22 @@ abstract class BaseGameActivity : ImmersiveActivity() {
     }
 
     private fun setupGamePadMotions() {
-        motionEventsSubjects
+        Observables.combineLatest(getGamePadPortMappingsObservable(), motionEventsSubjects)
             .autoDispose(scope())
-            .subscribeBy { sendMotionEvent(it) }
+            .subscribeBy { (ports, event) -> sendMotionEvent(event, ports[event.deviceId] ?: 0) }
     }
 
     private fun setupGamePadKeys() {
-        val bindKeys = Observables.combineLatest(getGamePadBindingsObservable(), keyEventsSubjects)
-            .map { (bindings, event) ->
-                val port = getDevicePort(event)
+        val bindKeys = Observables.combineLatest(
+            getGamePadPortMappingsObservable(),
+            getGamePadBindingsObservable(),
+            keyEventsSubjects
+        )
+            .map { (ports, bindings, event) ->
+                val port = ports[event.deviceId] ?: 0
                 val bindKeyCode = bindings[event.device]?.get(event.keyCode) ?: event.keyCode
                 Triple(event.action, port, bindKeyCode)
             }
-            .filter { (_, port, _) -> port >= 0 }
             .share()
 
         bindKeys
@@ -367,8 +370,14 @@ abstract class BaseGameActivity : ImmersiveActivity() {
             .map { it.toMap() }
     }
 
-    private fun sendMotionEvent(event: MotionEvent) {
-        val port = getDevicePort(event)
+    private fun getGamePadPortMappingsObservable(): Observable<Map<Int, Int>> {
+        return gamePadManager.getGamePadsObservable().map {
+            it.mapIndexed { index, inputDevice -> inputDevice.id to index }
+                .toMap()
+        }
+    }
+
+    private fun sendMotionEvent(event: MotionEvent, port: Int) {
         if (port < 0) return
         when (event.source) {
             InputDevice.SOURCE_JOYSTICK -> {

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/settings/GamePadManager.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/settings/GamePadManager.kt
@@ -38,7 +38,7 @@ class GamePadManager(context: Context) {
         val actionCompletable = Completable.fromAction {
             val editor = sharedPreferences.edit()
             sharedPreferences.all.keys
-                .filter { it.startsWith(GAME_PAD_PREFERENCE_BASE_KEY) }
+                .filter { it.startsWith(GAME_PAD_BINDING_PREFERENCE_BASE_KEY) }
                 .forEach { editor.remove(it) }
             editor.commit()
         }
@@ -90,19 +90,22 @@ class GamePadManager(context: Context) {
         return runCatching {
             InputDevice.getDeviceIds()
                 .map { InputDevice.getDevice(it) }
-                .filter { it.controllerNumber > 0 }
-                .distinctBy { it.controllerNumber }
+                .filter { isGamePad(it) }
                 .sortedBy { it.controllerNumber }
         }.getOrNull() ?: listOf()
     }
 
+    private fun isGamePad(device: InputDevice): Boolean {
+        return device.sources and InputDevice.SOURCE_GAMEPAD == InputDevice.SOURCE_GAMEPAD
+    }
+
     companion object {
-        private const val GAME_PAD_PREFERENCE_BASE_KEY = "pref_key_gamepad_binding"
+        private const val GAME_PAD_BINDING_PREFERENCE_BASE_KEY = "pref_key_gamepad_binding"
 
         private fun getSharedPreferencesId(inputDevice: InputDevice) = inputDevice.descriptor
 
         fun computeKeyBindingPreference(inputDevice: InputDevice, keyCode: Int) =
-            "${GAME_PAD_PREFERENCE_BASE_KEY}_${getSharedPreferencesId(inputDevice)}_$keyCode"
+            "${GAME_PAD_BINDING_PREFERENCE_BASE_KEY}_${getSharedPreferencesId(inputDevice)}_$keyCode"
 
         val INPUT_KEYS = listOf(
             KeyEvent.KEYCODE_BUTTON_A,

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/settings/GamePadSettingsPreferences.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/settings/GamePadSettingsPreferences.kt
@@ -7,9 +7,13 @@ import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceScreen
+import androidx.preference.SwitchPreference
 import com.swordfish.lemuroid.R
 
-class GamePadBindingsPreferences(private val gamePadManager: GamePadManager) {
+class GamePadSettingsPreferences(
+    private val gamePadManager: GamePadManager,
+    private val isLeanback: Boolean
+) {
 
     fun resetAllBindings() = gamePadManager.resetAllBindings()
 
@@ -24,11 +28,23 @@ class GamePadBindingsPreferences(private val gamePadManager: GamePadManager) {
         val categoryTitle = context.resources.getString(R.string.settings_gamepad_category_general)
         val category = createCategory(context, preferenceScreen, categoryTitle)
 
-        val preference = Preference(context)
-        preference.key = context.resources.getString(R.string.pref_key_reset_gamepad_bindings)
-        preference.title = context.resources.getString(R.string.settings_gamepad_title_reset_bindings)
-        preference.isIconSpaceReserved = false
-        category.addPreference(preference)
+        Preference(context).apply {
+            key = context.resources.getString(R.string.pref_key_reset_gamepad_bindings)
+            title = context.resources.getString(R.string.settings_gamepad_title_reset_bindings)
+            isIconSpaceReserved = false
+            category.addPreference(this)
+        }
+
+        if (!isLeanback) {
+            SwitchPreference(context).apply {
+                key = context.resources.getString(R.string.pref_key_allow_hide_touch_controls)
+                title = context.resources.getString(R.string.settings_gamepad_title_allow_hide_touch_controls)
+                summary = context.resources.getString(R.string.settings_gamepad_description_allow_hide_touch_controls)
+                setDefaultValue(true)
+                isIconSpaceReserved = false
+                category.addPreference(this)
+            }
+        }
     }
 
     private fun createCategory(

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/tv/settings/TVSettingsActivity.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/tv/settings/TVSettingsActivity.kt
@@ -2,6 +2,8 @@ package com.swordfish.lemuroid.app.tv.settings
 
 import android.os.Bundle
 import androidx.fragment.app.Fragment
+import com.swordfish.lemuroid.app.shared.settings.GamePadSettingsPreferences
+import com.swordfish.lemuroid.app.shared.settings.GamePadManager
 import com.swordfish.lemuroid.app.shared.settings.SettingsInteractor
 import com.swordfish.lemuroid.app.tv.shared.TVBaseSettingsActivity
 import com.swordfish.lemuroid.lib.injection.PerActivity
@@ -39,6 +41,12 @@ class TVSettingsActivity : TVBaseSettingsActivity() {
             @PerActivity
             @JvmStatic
             fun settingsInteractor(activity: TVSettingsActivity) = SettingsInteractor(activity)
+
+            @Provides
+            @PerActivity
+            @JvmStatic
+            fun gamepadSettingsPreferences(gamePadManager: GamePadManager) =
+                GamePadSettingsPreferences(gamePadManager, true)
         }
     }
 }

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/tv/settings/TVSettingsFragment.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/tv/settings/TVSettingsFragment.kt
@@ -7,7 +7,7 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceScreen
 import com.swordfish.lemuroid.R
 import com.swordfish.lemuroid.app.shared.settings.BiosPreferences
-import com.swordfish.lemuroid.app.shared.settings.GamePadBindingsPreferences
+import com.swordfish.lemuroid.app.shared.settings.GamePadSettingsPreferences
 import com.swordfish.lemuroid.app.shared.settings.GamePadManager
 import com.swordfish.lemuroid.app.shared.settings.SettingsInteractor
 import com.uber.autodispose.android.lifecycle.scope
@@ -20,7 +20,7 @@ class TVSettingsFragment : LeanbackPreferenceFragmentCompat() {
 
     @Inject lateinit var settingsInteractor: SettingsInteractor
     @Inject lateinit var biosPreferences: BiosPreferences
-    @Inject lateinit var gamePadBindingsPreferences: GamePadBindingsPreferences
+    @Inject lateinit var gamePadSettingsPreferences: GamePadSettingsPreferences
     @Inject lateinit var gamePadManager: GamePadManager
 
     override fun onAttach(context: Context) {
@@ -56,7 +56,7 @@ class TVSettingsFragment : LeanbackPreferenceFragmentCompat() {
     private fun refreshGamePadBindingsScreen() {
         getGamePadPreferenceScreen()?.let {
             it.removeAll()
-            gamePadBindingsPreferences.addGamePadsPreferencesToScreen(requireContext(), it)
+            gamePadSettingsPreferences.addGamePadsPreferencesToScreen(requireContext(), it)
         }
     }
 
@@ -69,7 +69,7 @@ class TVSettingsFragment : LeanbackPreferenceFragmentCompat() {
     }
 
     private fun handleResetGamePadBindings() {
-        gamePadBindingsPreferences.resetAllBindings()
+        gamePadSettingsPreferences.resetAllBindings()
             .observeOn(AndroidSchedulers.mainThread())
             .autoDispose(scope())
             .subscribe { refreshGamePadBindingsScreen() }

--- a/lemuroid-app/src/main/res/layout/activity_game.xml
+++ b/lemuroid-app/src/main/res/layout/activity_game.xml
@@ -28,6 +28,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".app.mobile.feature.game.GameActivity"
+    android:animateLayoutChanges="true"
     tools:ignore="MergeRootFrame">
 
     <FrameLayout

--- a/lemuroid-app/src/main/res/values/keys.xml
+++ b/lemuroid-app/src/main/res/values/keys.xml
@@ -8,6 +8,7 @@
     <string name="pref_key_tilt_sensitivity_index" translatable="false">tilt_sensitivity_index</string>
     <string name="pref_key_autosave" translatable="false">autosave</string>
     <string name="pref_key_reset_settings" translatable="false">reset_settings</string>
+    <string name="pref_key_allow_hide_touch_controls" translatable="false">allow_hide_touch_controls</string>
 
     <string name="pref_key_shader_filter" translatable="false">shader_filter</string>
 

--- a/lemuroid-app/src/main/res/values/strings.xml
+++ b/lemuroid-app/src/main/res/values/strings.xml
@@ -30,6 +30,8 @@
 
     <string name="settings_gamepad_category_general">General</string>
     <string name="settings_gamepad_title_reset_bindings">Reset bindings</string>
+    <string name="settings_gamepad_title_allow_hide_touch_controls">Auto hide touch controls</string>
+    <string name="settings_gamepad_description_allow_hide_touch_controls">Automatically hide touch controls when a GamePad is connected</string>
 
     <string name="settings_title_display_bios_info">BIOS</string>
     <string name="settings_description_display_bios_info">Display detected and supported BIOS files</string>


### PR DESCRIPTION
Allow manual override to always display touch controls.