### PR TITLE
Save savegames more regularly to disk to prevent loss

### DIFF
--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/game/BaseGameActivity.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/game/BaseGameActivity.kt
@@ -789,6 +789,13 @@ abstract class BaseGameActivity : ImmersiveActivity() {
         }
     }
 
+    override fun onPause() {
+        GlobalScope.launch {
+            saveSRAM(game)
+        }
+        super.onPause()
+    }
+
     private suspend fun autoSaveAndFinish() = withLoading {
         saveSRAM(game)
         saveAutoSave(game)


### PR DESCRIPTION
This partially fixes #527.

now, whenever the onPause function from the game activity is called, the savegame is persisted to disk. This should prevent most cases of savegame-loss.

It only partially fixes this because it does not help in case of a crash or poweroff where onPause is not called. It will probably nessessary to add a timerfunction that regularly calls the saveSRam function every X-minutes (or better yet, when it changes but i dont know if it is possible to hook into that.)

This was tested with gba-games