### PR TITLE
Sync savegames with SAF

### DIFF
--- a/lemuroid-app/src/main/AndroidManifest.xml
+++ b/lemuroid-app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="com.android.providers.tv.permission.WRITE_EPG_DATA" />
 
@@ -77,6 +78,9 @@
         <activity
             android:name="com.swordfish.lemuroid.app.shared.settings.StorageFrameworkPickerLauncher"
             android:theme="@style/LemuroidMaterialTheme.Invisible" />
+        <activity
+            android:name="com.swordfish.lemuroid.app.shared.settings.SAFSavePickerLauncher"
+            android:theme="@style/InvisibleTheme"/>
 
         <!-- Leanback activities -->
         <activity

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/LemuroidApplicationModule.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/LemuroidApplicationModule.kt
@@ -34,10 +34,7 @@ import com.swordfish.lemuroid.app.shared.game.GameLauncher
 import com.swordfish.lemuroid.app.shared.input.InputDeviceManager
 import com.swordfish.lemuroid.app.shared.main.GameLaunchTaskHandler
 import com.swordfish.lemuroid.app.shared.rumble.RumbleManager
-import com.swordfish.lemuroid.app.shared.settings.BiosPreferences
-import com.swordfish.lemuroid.app.shared.settings.ControllerConfigsManager
-import com.swordfish.lemuroid.app.shared.settings.CoresSelectionPreferences
-import com.swordfish.lemuroid.app.shared.settings.StorageFrameworkPickerLauncher
+import com.swordfish.lemuroid.app.shared.settings.*
 import com.swordfish.lemuroid.app.tv.channel.ChannelHandler
 import com.swordfish.lemuroid.ext.feature.core.CoreUpdaterImpl
 import com.swordfish.lemuroid.ext.feature.review.ReviewManager
@@ -111,6 +108,10 @@ abstract class LemuroidApplicationModule {
     @PerActivity
     @ContributesAndroidInjector
     abstract fun storageFrameworkPickerLauncher(): StorageFrameworkPickerLauncher
+
+    @PerActivity
+    @ContributesAndroidInjector
+    abstract fun savegameFolderPickerLauncher(): SAFSavePickerLauncher
 
     @PerActivity
     @ContributesAndroidInjector(modules = [GamePadBindingActivity.Module::class])

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/settings/SettingsFragment.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/settings/SettingsFragment.kt
@@ -62,6 +62,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
         val settingsViewModel = ViewModelProvider(this, factory)[SettingsViewModel::class.java]
 
         val currentDirectory: Preference? = findPreference(getString(R.string.pref_key_extenral_folder))
+        val currentSaveDirectory: Preference? = findPreference(getString(R.string.pref_key_external_save_folder))
         val rescanPreference: Preference? = findPreference(getString(R.string.pref_key_rescan))
         val stopRescanPreference: Preference? = findPreference(getString(R.string.pref_key_stop_rescan))
         val displayBiosPreference: Preference? = findPreference(getString(R.string.pref_key_display_bios_info))
@@ -75,9 +76,18 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 }
         }
 
+        launchOnState(Lifecycle.State.RESUMED) {
+            settingsViewModel.currentSavegameFolder
+                .collect {
+                    currentSaveDirectory?.summary = getDisplayNameForFolderUri(Uri.parse(it))
+                        ?: getString(R.string.none)
+                }
+        }
+
         settingsViewModel.indexingInProgress.observe(this) {
             rescanPreference?.isEnabled = !it
             currentDirectory?.isEnabled = !it
+            currentSaveDirectory?.isEnabled = !it
             displayBiosPreference?.isEnabled = !it
             resetSettings?.isEnabled = !it
         }
@@ -99,6 +109,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
             getString(R.string.pref_key_rescan) -> rescanLibrary()
             getString(R.string.pref_key_stop_rescan) -> stopRescanLibrary()
             getString(R.string.pref_key_extenral_folder) -> handleChangeExternalFolder()
+            getString(R.string.pref_key_external_save_folder) -> handleChangeExternalSaveFolder()
             getString(R.string.pref_key_open_gamepad_settings) -> handleOpenGamePadSettings()
             getString(R.string.pref_key_open_save_sync_settings) -> handleDisplaySaveSync()
             getString(R.string.pref_key_open_cores_selection) -> handleDisplayCorePage()
@@ -131,6 +142,10 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
     private fun handleChangeExternalFolder() {
         settingsInteractor.changeLocalStorageFolder()
+    }
+
+    private fun handleChangeExternalSaveFolder() {
+        settingsInteractor.changeSavegameFolder()
     }
 
     private fun handleResetSettings() {

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/settings/SettingsViewModel.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/settings/SettingsViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.launch
 class SettingsViewModel(
     context: Context,
     directoryPreference: String,
+    savegameDirectoryPreference: String,
     sharedPreferences: FlowSharedPreferences
 ) : ViewModel() {
 
@@ -25,11 +26,14 @@ class SettingsViewModel(
 
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             val directoryPreference = context.getString(R.string.pref_key_extenral_folder)
-            return SettingsViewModel(context, directoryPreference, sharedPreferences) as T
+            val savegameDirectoryPreference = context.getString(R.string.pref_key_external_save_folder)
+            return SettingsViewModel(context, directoryPreference, savegameDirectoryPreference, sharedPreferences) as T
         }
     }
 
     val currentFolder = MutableStateFlow("")
+
+    val currentSavegameFolder = MutableStateFlow("")
 
     val indexingInProgress = PendingOperationsMonitor(context).anyLibraryOperationInProgress()
 
@@ -40,6 +44,12 @@ class SettingsViewModel(
             sharedPreferences.getString(directoryPreference).asFlow()
                 .flowOn(Dispatchers.IO)
                 .collect { currentFolder.value = it }
+        }
+
+        viewModelScope.launch {
+            sharedPreferences.getString(savegameDirectoryPreference).asFlow()
+                .flowOn(Dispatchers.IO)
+                .collect { currentSavegameFolder.value = it }
         }
     }
 }

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/game/BaseGameActivity.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/game/BaseGameActivity.kt
@@ -857,7 +857,7 @@ abstract class BaseGameActivity : ImmersiveActivity() {
     private suspend fun saveSRAM(game: Game) {
         val retroGameView = retroGameView ?: return
         val sramState = retroGameView.serializeSRAM()
-        legacySavesManager.setSaveRAM(game, sramState)
+        legacySavesManager.setSaveRAM(game, sramState, applicationContext)
         Timber.i("Stored sram file with size: ${sramState.size}")
     }
 

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/game/BaseGameActivity.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/game/BaseGameActivity.kt
@@ -782,6 +782,15 @@ abstract class BaseGameActivity : ImmersiveActivity() {
         return super.onKeyUp(keyCode, event)
     }
 
+
+    override fun onPause() {
+        super.onPause()
+        lifecycleScope.launch {
+            // first save, then copy to external
+            saveSRAM(game)
+            legacySavesManager.copyToExternal(getString(system.shortTitleResId), game, applicationContext)
+        }
+    }
     override fun onBackPressed() {
         if (loadingState.value) return
         lifecycleScope.launch {
@@ -790,7 +799,9 @@ abstract class BaseGameActivity : ImmersiveActivity() {
     }
 
     private suspend fun autoSaveAndFinish() = withLoading {
+        // first save, then copy to external
         saveSRAM(game)
+        legacySavesManager.copyToExternal(getString(system.shortTitleResId), game, applicationContext)
         saveAutoSave(game)
         performSuccessfulActivityFinish()
     }
@@ -857,7 +868,7 @@ abstract class BaseGameActivity : ImmersiveActivity() {
     private suspend fun saveSRAM(game: Game) {
         val retroGameView = retroGameView ?: return
         val sramState = retroGameView.serializeSRAM()
-        legacySavesManager.setSaveRAM(game, sramState, applicationContext)
+        legacySavesManager.setSaveRAM(game, sramState)
         Timber.i("Stored sram file with size: ${sramState.size}")
     }
 

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/settings/SAFSavePickerLauncher.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/settings/SAFSavePickerLauncher.kt
@@ -1,0 +1,88 @@
+package com.swordfish.lemuroid.app.shared.settings
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import androidx.documentfile.provider.DocumentFile
+import com.swordfish.lemuroid.R
+import com.swordfish.lemuroid.app.utils.android.displayErrorDialog
+import com.swordfish.lemuroid.lib.android.RetrogradeActivity
+import com.swordfish.lemuroid.lib.preferences.SharedPreferencesHelper
+import com.swordfish.lemuroid.lib.storage.DirectoriesManager
+import javax.inject.Inject
+
+
+class SAFSavePickerLauncher : RetrogradeActivity() {
+
+    @Inject lateinit var directoriesManager: DirectoriesManager
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        if (savedInstanceState == null) {
+            val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
+                this.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                this.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+                this.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION)
+                this.addFlags(Intent.FLAG_GRANT_PREFIX_URI_PERMISSION)
+                this.putExtra(Intent.EXTRA_LOCAL_ONLY, true)
+            }
+            try {
+                startActivityForResult(intent, REQUEST_CODE_PICK_SAVEGAMEFOLDER)
+            } catch (e: Exception) {
+                showStorageAccessFrameworkNotSupportedDialog()
+            }
+        }
+    }
+
+    private fun showStorageAccessFrameworkNotSupportedDialog() {
+        val message = getString(R.string.dialog_saf_not_found, directoriesManager.getInternalRomsDirectory())
+        val actionLabel = getString(R.string.ok)
+        displayErrorDialog(message, actionLabel) { finish() }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, resultData: Intent?) {
+        super.onActivityResult(requestCode, resultCode, resultData)
+
+        if (requestCode == REQUEST_CODE_PICK_SAVEGAMEFOLDER && resultCode == Activity.RESULT_OK) {
+            val sharedPreferences = SharedPreferencesHelper.getLegacySharedPreferences(this)
+            val preferenceKey = getString(R.string.pref_key_external_save_folder)
+
+            val currentValue: String? = sharedPreferences.getString(preferenceKey, null)
+            val newValue = resultData?.data
+
+            if (newValue != null && newValue.toString() != currentValue) {
+                updatePersistableUrisRW(newValue)
+
+                sharedPreferences.edit().apply {
+                    this.putString(preferenceKey, newValue.toString())
+                    this.apply()
+                }
+            }
+        }
+        finish()
+    }
+
+    private fun updatePersistableUrisRW(uri: Uri) {
+
+        grantUriPermission(
+            packageName,
+            uri,
+            Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+        )
+        contentResolver.takePersistableUriPermission(
+            uri,
+            Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+        )
+    }
+
+    companion object {
+        private const val REQUEST_CODE_PICK_SAVEGAMEFOLDER = 2
+
+        fun pickSavegameFolder(context: Context) {
+            context.startActivity(Intent(context, SAFSavePickerLauncher::class.java))
+        }
+    }
+}

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/settings/SAFSavePickerLauncher.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/settings/SAFSavePickerLauncher.kt
@@ -70,11 +70,11 @@ class SAFSavePickerLauncher : RetrogradeActivity() {
         grantUriPermission(
             packageName,
             uri,
-            Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+            Intent.FLAG_GRANT_READ_URI_PERMISSION and Intent.FLAG_GRANT_WRITE_URI_PERMISSION
         )
         contentResolver.takePersistableUriPermission(
             uri,
-            Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+            Intent.FLAG_GRANT_READ_URI_PERMISSION and Intent.FLAG_GRANT_WRITE_URI_PERMISSION
         )
     }
 

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/settings/SettingsInteractor.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/settings/SettingsInteractor.kt
@@ -14,6 +14,10 @@ class SettingsInteractor(
         StorageFrameworkPickerLauncher.pickFolder(context)
     }
 
+    fun changeSavegameFolder() {
+        SAFSavePickerLauncher.pickSavegameFolder(context)
+    }
+
     fun resetAllSettings() {
         SharedPreferencesHelper.getLegacySharedPreferences(context).edit().clear().apply()
         SharedPreferencesHelper.getSharedPreferences(context).edit().clear().apply()

--- a/lemuroid-app/src/main/res/values/strings.xml
+++ b/lemuroid-app/src/main/res/values/strings.xml
@@ -199,4 +199,7 @@
     <string name="haptic_feedback_mode_names_press">Press</string>
     <string name="haptic_feedback_mode_names_press_release">Press &amp; release</string>
 
+    <string name="savedirectory">Savegame Directory</string>
+    <string name="savegames">Savegames</string>
+
 </resources>

--- a/lemuroid-app/src/main/res/xml/mobile_settings.xml
+++ b/lemuroid-app/src/main/res/xml/mobile_settings.xml
@@ -29,6 +29,18 @@
     </PreferenceCategory>
 
     <PreferenceCategory
+        android:title="@string/savegames"
+        app:iconSpaceReserved="false">
+
+        <Preference
+            android:key="@string/pref_key_external_save_folder"
+            android:title="@string/savedirectory"
+            app:iconSpaceReserved="false"
+            app:summary="@string/none"
+            app:useSimpleSummaryProvider="true"/>
+    </PreferenceCategory>
+
+    <PreferenceCategory
         android:title="@string/settings_category_general"
         app:iconSpaceReserved="false">
 

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/game/GameLoader.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/game/GameLoader.kt
@@ -91,7 +91,7 @@ class GameLoader(
             }.getOrElse { throw it }
 
             val saveRAMData = runCatching {
-                legacySavesManager.getSaveRAM(game)
+                legacySavesManager.getSaveRAM(game, appContext)
             }.getOrElse { throw GameLoaderException(GameLoaderError.Saves) }
 
             val quickSaveData = runCatching {
@@ -109,7 +109,7 @@ class GameLoader(
                 .toTypedArray()
 
             val systemDirectory = directoriesManager.getSystemDirectory()
-            val savesDirectory = directoriesManager.getSavesDirectory()
+            val savesDirectory = directoriesManager.getInternalSavesDirectroy()
 
             emit(
                 LoadingState.Ready(

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/game/GameLoader.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/game/GameLoader.kt
@@ -91,7 +91,8 @@ class GameLoader(
             }.getOrElse { throw it }
 
             val saveRAMData = runCatching {
-                legacySavesManager.getSaveRAM(game, appContext)
+                legacySavesManager.copyToInternal(appContext.getString(system.shortTitleResId), game, appContext)
+                legacySavesManager.getSaveRAM(game)
             }.getOrElse { throw GameLoaderException(GameLoaderError.Saves) }
 
             val quickSaveData = runCatching {

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/saves/SavesManager.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/saves/SavesManager.kt
@@ -13,9 +13,9 @@ import java.io.ByteArrayOutputStream
 class SavesManager(private val directoriesManager: DirectoriesManager) {
 
     suspend fun getSaveRAM(game: Game, context: Context): ByteArray? = withContext(Dispatchers.IO) {
-        val ramFileName = getSaveRAMFileName(game)
-        copyToInternal(ramFileName, context)
         val result = runCatchingWithRetry(FILE_ACCESS_RETRIES) {
+            val ramFileName = getSaveRAMFileName(game)
+            copyToInternal(ramFileName, context)
             val saveFile = getSaveFile(ramFileName)
             if (saveFile.exists() && saveFile.length() > 0) {
                 saveFile.readBytes()

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/saves/SavesManager.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/saves/SavesManager.kt
@@ -1,17 +1,22 @@
 package com.swordfish.lemuroid.lib.saves
 
+import android.content.Context
 import com.swordfish.lemuroid.common.kotlin.runCatchingWithRetry
 import com.swordfish.lemuroid.lib.library.db.entity.Game
 import com.swordfish.lemuroid.lib.storage.DirectoriesManager
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.io.ByteArrayOutputStream
 
 class SavesManager(private val directoriesManager: DirectoriesManager) {
 
-    suspend fun getSaveRAM(game: Game): ByteArray? = withContext(Dispatchers.IO) {
+    suspend fun getSaveRAM(game: Game, context: Context): ByteArray? = withContext(Dispatchers.IO) {
+        val ramFileName = getSaveRAMFileName(game)
+        copyToInternal(ramFileName, context)
         val result = runCatchingWithRetry(FILE_ACCESS_RETRIES) {
-            val saveFile = getSaveFile(getSaveRAMFileName(game))
+            val saveFile = getSaveFile(ramFileName)
             if (saveFile.exists() && saveFile.length() > 0) {
                 saveFile.readBytes()
             } else {
@@ -21,13 +26,15 @@ class SavesManager(private val directoriesManager: DirectoriesManager) {
         result.getOrNull()
     }
 
-    suspend fun setSaveRAM(game: Game, data: ByteArray): Unit = withContext(Dispatchers.IO) {
+    suspend fun setSaveRAM(game: Game, data: ByteArray, context: Context): Unit = withContext(Dispatchers.IO) {
+        val ramFileName = getSaveRAMFileName(game)
         val result = runCatchingWithRetry(FILE_ACCESS_RETRIES) {
             if (data.isEmpty())
                 return@runCatchingWithRetry
 
-            val saveFile = getSaveFile(getSaveRAMFileName(game))
+            val saveFile = getSaveFile(ramFileName)
             saveFile.writeBytes(data)
+            copyToExternal(ramFileName, context)
         }
         result.getOrNull()
     }
@@ -39,7 +46,7 @@ class SavesManager(private val directoriesManager: DirectoriesManager) {
     }
 
     private suspend fun getSaveFile(fileName: String): File = withContext(Dispatchers.IO) {
-        val savesDirectory = directoriesManager.getSavesDirectory()
+        val savesDirectory = directoriesManager.getInternalSavesDirectroy()
         File(savesDirectory, fileName)
     }
 
@@ -48,5 +55,50 @@ class SavesManager(private val directoriesManager: DirectoriesManager) {
 
     companion object {
         private const val FILE_ACCESS_RETRIES = 3
+    }
+
+    private suspend fun copyToInternal(filename: String, context: Context) {
+        Timber.i("Sync Savegamedata from external storage if required.")
+        val internalSaveFile = getSaveFile(filename)
+        directoriesManager.getSavesDirectory().let {
+            val test = it?.findFile(filename)
+            if(test != null) {
+                // File in external storage is newer, so copy it to local
+                if(internalSaveFile.lastModified() < test.lastModified()) {
+                    val inputStream = context.contentResolver.openInputStream(test.uri)
+
+                    val byteBuffer = ByteArrayOutputStream()
+                    val bufferSize = test.length()
+
+                    // toInt is valid, since saveFile.readBytes() has an internal limitation of 2Gb anyway
+                    val buffer = ByteArray(bufferSize.toInt())
+                    var len = 0
+                    while (inputStream!!.read(buffer).also { len = it } != -1) {
+                        byteBuffer.write(buffer, 0, len)
+                    }
+
+                    if(!internalSaveFile.exists()){
+                        internalSaveFile.createNewFile()
+                    }
+                    internalSaveFile.writeBytes(buffer)
+                }
+            }
+        }
+    }
+
+    private suspend fun copyToExternal(filename: String, context: Context) {
+        Timber.i("Sync Savegamedata from internal storage if required.")
+        val internalSaveFile = getSaveFile(filename)
+
+        directoriesManager.getSavesDirectory().let {
+            val test = it?.findFile(filename)
+            if(test != null) {
+                // File in external storage is newer, so copy it to local
+                if(internalSaveFile.lastModified() > test.lastModified()) {
+                    val outputStream = context.contentResolver.openOutputStream(test.uri)
+                    outputStream?.write(internalSaveFile.readBytes())
+                }
+            }
+        }
     }
 }

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/saves/SavesManager.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/saves/SavesManager.kt
@@ -54,10 +54,10 @@ class SavesManager(private val directoriesManager: DirectoriesManager) {
 
     private fun getSavegameFilename(type: String, game: Game) : String {
         val gamename = game.fileName.substringBeforeLast(".")
-        return when(type) {
+        return when(type.lowercase()) {
             /** This name should make it compatible with RetroArch so that users can freely sync saves across the two application. */
             "gba" -> "$gamename.srm"
-            "nds" -> "$gamename.dsv"
+            "nds" -> "$gamename.sav"
             else -> {
                 Timber.e("Error syncing savegamedata: the proper fileending for ${game.title} with the $type-core is not configured.")
                 ""

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/saves/SavesManager.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/saves/SavesManager.kt
@@ -58,7 +58,10 @@ class SavesManager(private val directoriesManager: DirectoriesManager) {
             /** This name should make it compatible with RetroArch so that users can freely sync saves across the two application. */
             "gba" -> "$gamename.srm"
             "nds" -> "$gamename.dsv"
-            else -> ""
+            else -> {
+                Timber.e("Error syncing savegamedata: the proper fileending for ${game.title} with the $type-core is not configured.")
+                ""
+            }
         }
     }
 

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/storage/DirectoriesManager.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/storage/DirectoriesManager.kt
@@ -34,21 +34,15 @@ class DirectoriesManager(private val appContext: Context) {
         mkdirs()
     }
 
-    fun getSavesDirectory(): File {
-        Log.e("tag", "getSaveDir")
+    fun getSavesDirectory(): DocumentFile? {
         val sharedPreferences = SharedPreferencesHelper.getLegacySharedPreferences(appContext)
         val preferenceKey = appContext.getString(R.string.pref_key_external_save_folder)
-
         val saveFolder: String? = sharedPreferences.getString(preferenceKey, null)
-        val romFolder: String? = sharedPreferences.getString(appContext.getString(R.string.pref_key_extenral_folder), null)
+        return DocumentFile.fromTreeUri(appContext, Uri.parse(saveFolder))
+    }
 
-        val folder = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS)
-        val saves = File(folder.absolutePath, "saves")
-
-        val t = saves.mkdirs()
-
-        Log.e("tag", "getSaveDir" +saves + t)
-        return saves
+    fun getInternalSavesDirectroy(): File = File(appContext.getExternalFilesDir(null), "saves").apply {
+        mkdirs()
     }
 
     fun getInternalRomsDirectory(): File = File(appContext.getExternalFilesDir(null), "roms").apply {

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/storage/DirectoriesManager.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/storage/DirectoriesManager.kt
@@ -1,6 +1,14 @@
 package com.swordfish.lemuroid.lib.storage
 
 import android.content.Context
+import android.net.Uri
+import android.os.Environment
+import android.util.Log
+import androidx.core.net.toFile
+import androidx.documentfile.provider.DocumentFile
+import com.swordfish.lemuroid.lib.R
+import com.swordfish.lemuroid.lib.preferences.SharedPreferencesHelper
+
 import java.io.File
 
 class DirectoriesManager(private val appContext: Context) {
@@ -26,8 +34,21 @@ class DirectoriesManager(private val appContext: Context) {
         mkdirs()
     }
 
-    fun getSavesDirectory(): File = File(appContext.getExternalFilesDir(null), "saves").apply {
-        mkdirs()
+    fun getSavesDirectory(): File {
+        Log.e("tag", "getSaveDir")
+        val sharedPreferences = SharedPreferencesHelper.getLegacySharedPreferences(appContext)
+        val preferenceKey = appContext.getString(R.string.pref_key_external_save_folder)
+
+        val saveFolder: String? = sharedPreferences.getString(preferenceKey, null)
+        val romFolder: String? = sharedPreferences.getString(appContext.getString(R.string.pref_key_extenral_folder), null)
+
+        val folder = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS)
+        val saves = File(folder.absolutePath, "saves")
+
+        val t = saves.mkdirs()
+
+        Log.e("tag", "getSaveDir" +saves + t)
+        return saves
     }
 
     fun getInternalRomsDirectory(): File = File(appContext.getExternalFilesDir(null), "roms").apply {

--- a/retrograde-app-shared/src/main/res/values/keys.xml
+++ b/retrograde-app-shared/src/main/res/values/keys.xml
@@ -4,5 +4,6 @@
 
     <string name="pref_key_last_save_sync" translatable="false">last_save_sync</string>
     <string name="pref_key_extenral_folder" translatable="false">external_folder</string>
+    <string name="pref_key_external_save_folder" translatable="false">external_save_folder</string>
     <string name="pref_key_legacy_external_folder" translatable="false">legacy_external_folder</string>
 </resources>


### PR DESCRIPTION
This allows the user to use arbitrary locations for savegames. It uses the internal folder as a "working directory", copying files from and to selected external storage if choosen. The file with the last modification timestamp ALWAYS wins this sync.


This can replace the custom google-drive implementation. It is always called when SRAM is saved. It only copies the current game.

Todo:

- [ ] Add all cores
- [ ] Find out what a .dsv file is
- [ ] Find out which cores use the sram-function
- [ ] Make the sram-function with above cores