### PR TITLE
Bypass Screenrotationlock

### DIFF
--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/settings/SettingsManager.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/settings/SettingsManager.kt
@@ -2,6 +2,7 @@ package com.swordfish.lemuroid.app.mobile.feature.settings
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.content.pm.ActivityInfo
 import com.fredporciuncula.flow.preferences.FlowSharedPreferences
 import com.swordfish.lemuroid.R
 import com.swordfish.lemuroid.app.shared.settings.HDModeQuality
@@ -29,6 +30,16 @@ class SettingsManager(private val context: Context, sharedPreferences: Lazy<Shar
             R.string.pref_key_shader_filter,
             context.resources.getStringArray(R.array.pref_key_shader_filter_values).first(),
         )
+
+    suspend fun screenOrientation(): Int {
+        val key = stringPreference(R.string.pref_key_screen_rotation, "system")
+        return when(key) {
+            "portrait" -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
+            "landscape" -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+            "auto" -> ActivityInfo.SCREEN_ORIENTATION_SENSOR
+            else -> ActivityInfo.SCREEN_ORIENTATION_USER // Follow system
+        }
+    }
 
     suspend fun hdMode() = booleanPreference(R.string.pref_key_hd_mode, false)
 

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/settings/general/SettingsScreen.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/settings/general/SettingsScreen.kt
@@ -173,6 +173,16 @@ private fun GeneralSettings() {
             title = { Text(text = stringResource(id = R.string.display_filter)) },
             items = stringListResource(R.array.pref_key_shader_filter_display_names),
         )
+        LemuroidSettingsList(
+            state =
+            indexPreferenceState(
+                R.string.pref_key_screen_rotation,
+                "portrait",
+                stringListResource(R.array.pref_key_screen_rotation_values).toList(),
+            ),
+            title = { Text(text = stringResource(id = R.string.settings_title_screen_orientation)) },
+            items = stringListResource(R.array.pref_key_screen_rotation_display_names),
+        )
     }
 }
 

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/game/BaseGameActivity.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/game/BaseGameActivity.kt
@@ -173,6 +173,7 @@ abstract class BaseGameActivity : ImmersiveActivity() {
 
         lifecycleScope.launch {
             loadGame()
+            requestedOrientation = settingsManager.screenOrientation()
         }
 
         initialiseFlows()

--- a/lemuroid-app/src/main/res/values/keys.xml
+++ b/lemuroid-app/src/main/res/values/keys.xml
@@ -27,6 +27,7 @@
 
     <string name="pref_key_shader_filter" translatable="false">shader_filter_0</string>
     <string name="pref_key_hd_mode" translatable="false">hd_mode</string>
+    <string name="pref_key_screen_rotation" translatable="false">screen_rotation</string>
 
     <string-array translatable="false" name="pref_key_haptic_feedback_mode_values">
         <item>none</item>
@@ -54,5 +55,20 @@
         <item>@string/shader_filter_names_smooth</item>
         <item>@string/shader_filter_names_crt</item>
         <item>@string/shader_filter_names_lcd</item>
+    </string-array>
+
+
+    <string-array translatable="false" name="pref_key_screen_rotation_values">
+        <item>system</item>
+        <item>landscape</item>
+        <item>portrait</item>
+        <item>auto</item>
+    </string-array>
+
+    <string-array translatable="false" name="pref_key_screen_rotation_display_names">
+        <item>@string/screen_rotation_display_system</item>
+        <item>@string/screen_rotation_display_landscape</item>
+        <item>@string/screen_rotation_display_portrait</item>
+        <item>@string/screen_rotation_display_auto</item>
     </string-array>
 </resources>

--- a/lemuroid-app/src/main/res/values/strings.xml
+++ b/lemuroid-app/src/main/res/values/strings.xml
@@ -37,6 +37,8 @@
     <string name="settings_description_hd_mode">Apply post-processing upscaling filter</string>
     <string name="settings_description_hd_quality">Adjust the quality of HD mode</string>
 
+    <string name="settings_title_screen_orientation">Screen Orientation</string>
+
     <string name="settings_title_gamepad_settings">External devices</string>
     <string name="settings_description_gamepad_settings">Configure external gamepads and keyboards</string>
 
@@ -207,5 +209,10 @@
     <string name="haptic_feedback_mode_names_none">None</string>
     <string name="haptic_feedback_mode_names_press">Press</string>
     <string name="haptic_feedback_mode_names_press_release">Press &amp; release</string>
+
+    <string name="screen_rotation_display_system">Follow Device Settings</string>
+    <string name="screen_rotation_display_landscape">Landscape</string>
+    <string name="screen_rotation_display_portrait">Portrait</string>
+    <string name="screen_rotation_display_auto">Auto</string>
 
 </resources>


### PR DESCRIPTION
Fixes #466

This adds a boolean setting that allows the user to force screen rotation to be independend of android.