### PR TITLE
feat: add publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,60 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+
+  build:
+    name: Build APK
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          cache: gradle
+
+      - name: Create release keystore
+        run: |
+          echo "${{ secrets.RELEASE_KEYSTORE }}" > release.keystore.asc
+          gpg -d --passphrase "${{ secrets.RELEASE_KEYSTORE_PASSPHRASE }}" --batch release.keystore.asc > release.jks
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run Assemble Artifact
+        run: ./gradlew assembleFreeDynamic
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          name: apk
+          path: lemuroid-app/build/outputs/apk/freeDynamic/release/lemuroid-app-free-dynamic-release.apk
+
+  publish_apk:
+    name: Publish APK on Github
+    needs: [ build ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v3.0.0
+        with:
+          name: apk
+
+      - name: Create pre-release
+        uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: true
+          title: "Pre-release"
+          files: lemuroid-app-free-dynamic-release.apk


### PR DESCRIPTION
In order to make this workflow executable we need the following action items:

- [ ] Change the permissions related to the `secrets.GITHUB_TOKEN`: repository settings > Actions > General, then clicks on: **Read and write permissions**
- [ ] We need to add two actions SECRETS: `RELEASE_KEYSTORE` which will contain the encrypted `release.keystore` and `RELEASE_KEYSTORE_PASSPHRASE` which will contain the **gpg passphrase** that decrypt the keystone.

The guide to creating those two secrets is here: https://stefma.medium.com/how-to-store-a-android-keystore-safely-on-github-actions-f0cef9413784 we can do it together.