### PR TITLE
Sort Savegames by system in internal storage

### DIFF
--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/game/BaseGameActivity.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/game/BaseGameActivity.kt
@@ -789,6 +789,13 @@ abstract class BaseGameActivity : ImmersiveActivity() {
         }
     }
 
+    override fun onPause() {
+        GlobalScope.launch {
+            saveSRAM(game)
+        }
+        super.onPause()
+    }
+
     private suspend fun autoSaveAndFinish() = withLoading {
         saveSRAM(game)
         saveAutoSave(game)

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/saves/SavesManager.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/saves/SavesManager.kt
@@ -28,6 +28,14 @@ class SavesManager(private val directoriesManager: DirectoriesManager) {
 
             val saveFile = getSystemSaveFile(game.systemId, getSaveRAMFileName(game))
             saveFile.writeBytes(data)
+
+            //clean up the legacy file. But only if the byteArrays match!
+            if(saveFile.readBytes().contentEquals(data)) {
+                val legacySaveFile = getLegacySaveFile(getSaveRAMFileName(game))
+                if(legacySaveFile.exists()) {
+                    legacySaveFile.delete()
+                }
+            }
         }
         result.getOrNull()
     }


### PR DESCRIPTION
This will create a folder for each system in internal memory. Other emulator-applications usually seperate savegames by their system name. When the internal storage is now synced to external ones, they are not "compatible" with those applications. (I mainly refer to how retropie handles this).

The changes work like this:

1. Core loads savegame. 
2. Savegame-file is detected as usual.
3. SavegameManager checks if a system/savename.srm-file exists
4. returns that if it is not empty
5. return legacy-save if it is empty.


Saving:
1. Save like usual, except use system/savename.srm-scheme
2. check if file has been written, and if legacy file exists.
3. If legacy file exists, delete it

This is really only useful with  #632 

Edit:

Since i am deleting savegames, this PR should be tested extensively. I can also remove the deletion and just keep the internal storage "cluttered", it shouldn't matter that much storage-wise.