### PR TITLE
Add more screen layout option for NDS emulators

### DIFF
--- a/lemuroid-touchinput/src/main/java/com/swordfish/touchinput/radial/LemuroidTouchConfigs.kt
+++ b/lemuroid-touchinput/src/main/java/com/swordfish/touchinput/radial/LemuroidTouchConfigs.kt
@@ -399,6 +399,16 @@ object LemuroidTouchConfigs {
                 listOf(
                     SecondaryDialConfig.SingleButton(2, 1f, 0f, BUTTON_CONFIG_R),
                     SecondaryDialConfig.SingleButton(4, 1f, 0f, BUTTON_CONFIG_START),
+                    SecondaryDialConfig.SingleButton(
+                        8,
+                        1f,
+                        0f,
+                        ButtonConfig(
+                            id = KeyEvent.KEYCODE_BUTTON_THUMBR,
+                            iconId = R.drawable.edit_reset,
+                            contentDescription = "Swap screen",
+                        ),
+                    ),
                     buildMenuButtonConfig(10, theme),
                 ),
         )
@@ -465,6 +475,16 @@ object LemuroidTouchConfigs {
                 listOf(
                     SecondaryDialConfig.SingleButton(2, 1f, 0f, BUTTON_CONFIG_R),
                     SecondaryDialConfig.SingleButton(4, 1f, 0f, BUTTON_CONFIG_START),
+                    SecondaryDialConfig.SingleButton(
+                        8,
+                        1f,
+                        0f,
+                        ButtonConfig(
+                            id = KeyEvent.KEYCODE_BUTTON_R2,
+                            iconId = R.drawable.edit_reset,
+                            contentDescription = "Cycle screens layout",
+                        ),
+                    ),
                     buildMenuButtonConfig(10, theme),
                 ),
         )

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/GameSystem.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/GameSystem.kt
@@ -944,20 +944,12 @@ data class GameSystem(
                                                 R.string.value_desmume_screens_layout_leftright,
                                             ),
                                             ExposedSetting.Value(
-                                                "hybrid/top",
-                                                R.string.value_desmume_screens_layout_hybridtop,
-                                            ),
-                                            ExposedSetting.Value(
                                                 "hybrid/bottom",
-                                                R.string.value_desmume_screens_layout_hybridbottom,
-                                            ),
-                                            ExposedSetting.Value(
-                                                "top only",
-                                                R.string.value_desmume_screens_layout_toponly,
+                                                R.string.value_desmume_screens_layout_hybrid,
                                             ),
                                             ExposedSetting.Value(
                                                 "bottom only",
-                                                R.string.value_desmume_screens_layout_bottomonly,
+                                                R.string.value_desmume_screens_layout_single,
                                             ),
                                         ),
                                     ),

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/GameSystem.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/GameSystem.kt
@@ -970,6 +970,8 @@ data class GameSystem(
                                 listOf(
                                     CoreVariable("desmume_pointer_type", "touch"),
                                     CoreVariable("desmume_frameskip", "1"),
+                                    CoreVariable("desmume_hybrid_showboth_screens", "disabled"),
+                                    CoreVariable("desmume_hybrid_layout_scale", "3")
                                 ),
                             controllerConfigs =
                                 hashMapOf(
@@ -983,7 +985,7 @@ data class GameSystem(
                                 listOf(
                                     ExposedSetting(
                                         "melonds_screen_layout1",
-                                        R.string.setting_melonds_screen_layout,
+                                        R.string.setting_melonds_screen_layout_1,
                                         arrayListOf(
                                             ExposedSetting.Value(
                                                 "top-bottom",
@@ -992,6 +994,36 @@ data class GameSystem(
                                             ExposedSetting.Value(
                                                 "left-right",
                                                 R.string.value_melonds_screen_layout_leftright,
+                                            ),
+                                            ExposedSetting.Value(
+                                                "hybrid-top",
+                                                R.string.value_melonds_screen_layout_hybridtop,
+                                            ),
+                                            ExposedSetting.Value(
+                                                "top",
+                                                R.string.value_melonds_screen_layout_top,
+                                            ),
+                                        ),
+                                    ),
+                                    ExposedSetting(
+                                        "melonds_screen_layout2",
+                                        R.string.setting_melonds_screen_layout_2,
+                                        arrayListOf(
+                                            ExposedSetting.Value(
+                                                "bottom-top",
+                                                R.string.value_melonds_screen_layout_bottomtop,
+                                            ),
+                                            ExposedSetting.Value(
+                                                "right-left",
+                                                R.string.value_melonds_screen_layout_rightleft,
+                                            ),
+                                            ExposedSetting.Value(
+                                                "hybrid-bottom",
+                                                R.string.value_melonds_screen_layout_hybridbottom,
+                                            ),
+                                            ExposedSetting.Value(
+                                                "bottom",
+                                                R.string.value_melonds_screen_layout_bottom,
                                             ),
                                         ),
                                     ),
@@ -1009,7 +1041,8 @@ data class GameSystem(
                                 ),
                             defaultSettings =
                                 listOf(
-                                    CoreVariable("melonds_number_of_screen_layouts", "1"),
+                                    CoreVariable("melonds_number_of_screen_layouts", "2"),
+                                    CoreVariable("melonds_hybrid_small_screen", "one"),
                                     CoreVariable("melonds_touch_mode", "Touch"),
                                     CoreVariable("melonds_threaded_renderer", "enabled"),
                                     // TODO... As soon as libretrodroid supports the microphone we can remove this.

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/GameSystem.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/GameSystem.kt
@@ -943,6 +943,22 @@ data class GameSystem(
                                                 "left/right",
                                                 R.string.value_desmume_screens_layout_leftright,
                                             ),
+                                            ExposedSetting.Value(
+                                                "hybrid/top",
+                                                R.string.value_desmume_screens_layout_hybridtop,
+                                            ),
+                                            ExposedSetting.Value(
+                                                "hybrid/bottom",
+                                                R.string.value_desmume_screens_layout_hybridbottom,
+                                            ),
+                                            ExposedSetting.Value(
+                                                "top only",
+                                                R.string.value_desmume_screens_layout_toponly,
+                                            ),
+                                            ExposedSetting.Value(
+                                                "bottom only",
+                                                R.string.value_desmume_screens_layout_bottomonly,
+                                            ),
                                         ),
                                     ),
                                     ExposedSetting(

--- a/retrograde-app-shared/src/main/res/values/strings.xml
+++ b/retrograde-app-shared/src/main/res/values/strings.xml
@@ -55,7 +55,8 @@
     <string name="setting_fbneo_cpu_speed_adjust">CPU speed</string>
     <string name="setting_desmume_screens_layout">Screens layout</string>
     <string name="setting_desmume_frameskip">Frameskip</string>
-    <string name="setting_melonds_screen_layout">Screens layout</string>
+    <string name="setting_melonds_screen_layout_1">Screens layout 1</string>
+    <string name="setting_melonds_screen_layout_2">Screens layout 2</string>
     <string name="setting_melonds_threaded_renderer">Threaded renderer</string>
     <string name="setting_melonds_jit_enable">Dynamic recompiler</string>
     <string name="setting_wswan_rotate_display">Orientation</string>
@@ -117,9 +118,13 @@
     <string name="value_mupen64plus_mupen64plus_pak2_rumble">Rumble</string>
 
     <string name="value_melonds_screen_layout_topbottom">Top - Bottom</string>
+    <string name="value_melonds_screen_layout_bottomtop">Bottom - Top</string>
     <string name="value_melonds_screen_layout_leftright">Left - Right</string>
+    <string name="value_melonds_screen_layout_rightleft">Right - Left</string>
     <string name="value_melonds_screen_layout_hybridtop">Hybrid Top</string>
     <string name="value_melonds_screen_layout_hybridbottom">Hybrid Bottom</string>
+    <string name="value_melonds_screen_layout_top">Top only</string>
+    <string name="value_melonds_screen_layout_bottom">Bottom only</string>
 
     <string name="value_citra_layout_option_topbottom">Top - Bottom</string>
     <string name="value_citra_layout_option_sidebyside">Left - Right</string>

--- a/retrograde-app-shared/src/main/res/values/strings.xml
+++ b/retrograde-app-shared/src/main/res/values/strings.xml
@@ -131,10 +131,8 @@
 
     <string name="value_desmume_screens_layout_topbottom">Top - Bottom</string>
     <string name="value_desmume_screens_layout_leftright">Left - Right</string>
-    <string name="value_desmume_screens_layout_hybridtop">Hybrid Top</string>
-    <string name="value_desmume_screens_layout_hybridbottom">Hybrid Bottom</string>
-    <string name="value_desmume_screens_layout_toponly">Top only</string>
-    <string name="value_desmume_screens_layout_bottomonly">Bottom only</string>
+    <string name="value_desmume_screens_layout_hybrid">Hybrid</string>
+    <string name="value_desmume_screens_layout_single">Single</string>
 
     <string name="value_ppsspp_cpu_core_jit">JIT</string>
     <string name="value_ppsspp_cpu_core_irjit">IR JIT</string>

--- a/retrograde-app-shared/src/main/res/values/strings.xml
+++ b/retrograde-app-shared/src/main/res/values/strings.xml
@@ -126,6 +126,10 @@
 
     <string name="value_desmume_screens_layout_topbottom">Top - Bottom</string>
     <string name="value_desmume_screens_layout_leftright">Left - Right</string>
+    <string name="value_desmume_screens_layout_hybridtop">Hybrid Top</string>
+    <string name="value_desmume_screens_layout_hybridbottom">Hybrid Bottom</string>
+    <string name="value_desmume_screens_layout_toponly">Top only</string>
+    <string name="value_desmume_screens_layout_bottomonly">Bottom only</string>
 
     <string name="value_ppsspp_cpu_core_jit">JIT</string>
     <string name="value_ppsspp_cpu_core_irjit">IR JIT</string>


### PR DESCRIPTION
Solves #618 and #208 (and similar issues) by showing more screen layout options for DeSmuME and melonDS, and adding a virtual button for screen swapping.

## DeSmuME

Available layouts:
- Top/Bottom
- Left/Right
- Hybrid
- Single

Tapping the swap button (or the R3 button on a gamepad) will swap the screens, based on the selected layout.

## melonDS

You can now specify two different layouts, and you can cycle them by tapping the swap button (or the R2 trigger on a controller).

Screens layout 1 choices:
- Top/Bottom
- Left/Right
- Hybrid/Top
- Top only

Screens layout 2 choices:
- Bottom/Top
- Right/Left
- Hybrid/Bottom
- Bottom only