### PR TITLE
Make fun isSAFSupported more reliable

### DIFF
--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/tv/shared/TVHelper.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/tv/shared/TVHelper.kt
@@ -8,17 +8,17 @@ object TVHelper {
     fun isSAFSupported(context: Context): Boolean {
         val packageManager = context.packageManager
 
-        val isStandardHardware =
-            listOf(
-                !packageManager.hasSystemFeature("android.hardware.type.television"),
-                !packageManager.hasSystemFeature("android.hardware.type.watch"),
-                !packageManager.hasSystemFeature("android.hardware.type.automotive"),
-            ).all { it }
+        // Devices that are known to have limited or no SAF support
+        val isLimitedDevice = packageManager.hasSystemFeature("android.hardware.type.television") ||
+                packageManager.hasSystemFeature("android.hardware.type.watch") ||
+                packageManager.hasSystemFeature("android.hardware.type.automotive")
 
-        val isNotLegacyStorage =
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && !Environment.isExternalStorageLegacy()
+        // Scoped storage check (relevant only for Android 10+)
+        val isScopedStorageRequired = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
+                !Environment.isExternalStorageLegacy()
 
-        return isStandardHardware || isNotLegacyStorage
+        // SAF is supported if it's not a limited device and meets storage requirements
+        return !isLimitedDevice && (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT || isScopedStorageRequired)
     }
 
     fun isTV(context: Context): Boolean {


### PR DESCRIPTION
The "fun isSAFSupported(context: Context): Boolean" is not always logical correct, therefore, in Android TV 11+, the return value is ture, but actually the SAF is not supported. The app throw an exception of SAF not supported.
ChatGPT provide a more reliable code as commited.

 Test OK with rom files in the path below:
/storage/emulated/0/Android/media/com.swordfish.lemuroid/files/roms