### PR TITLE
feat(settings): add vibration strength setting

### DIFF
--- a/buildSrc/src/main/java/deps.kt
+++ b/buildSrc/src/main/java/deps.kt
@@ -24,7 +24,7 @@ object deps {
         const val fragment        = "1.5.1"
         const val activity        = "1.7.2"
         const val libretrodroid   = "a2d8b3dc74"
-        const val radialgamepad   = "2.0.0"
+        const val radialgamepad   = "2.1.0"
         const val composeBom      = "2024.02.02"
 
         // Make sure this is compatible with current bom versions:

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/game/GameActivity.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/game/GameActivity.kt
@@ -57,6 +57,7 @@ import com.swordfish.radialgamepad.library.config.RadialGamePadTheme
 import com.swordfish.radialgamepad.library.event.Event
 import com.swordfish.radialgamepad.library.event.GestureType
 import com.swordfish.radialgamepad.library.haptics.HapticConfig
+import com.swordfish.radialgamepad.library.haptics.HapticStrength
 import com.swordfish.touchinput.radial.LemuroidTouchConfigs
 import com.swordfish.touchinput.radial.LemuroidTouchOverlayThemes
 import com.swordfish.touchinput.radial.sensors.TiltSensor
@@ -208,8 +209,9 @@ class GameActivity : BaseGameActivity() {
         orientation: Int,
     ) {
         val hapticFeedbackMode = settingsManager.hapticFeedbackMode()
+        val hapticStrength = settingsManager.hapticFeedbackStrength()
         withContext(Dispatchers.Main) {
-            setupTouchViews(controllerConfig, hapticFeedbackMode, orientation)
+            setupTouchViews(controllerConfig, hapticFeedbackMode, hapticStrength, orientation)
         }
         loadTouchControllerSettings(controllerConfig, orientation)
     }
@@ -232,6 +234,7 @@ class GameActivity : BaseGameActivity() {
     private fun setupTouchViews(
         controllerConfig: ControllerConfig,
         hapticFeedbackType: String,
+        hapticFeedbackStrength: HapticStrength,
         orientation: Int,
     ) {
         touchControllerJobs
@@ -258,6 +261,7 @@ class GameActivity : BaseGameActivity() {
             LemuroidTouchConfigs.getRadialGamePadConfig(
                 touchControllerConfig.leftConfig,
                 hapticConfig,
+                hapticFeedbackStrength,
                 theme,
             )
         val leftPad = RadialGamePad(leftConfig, DEFAULT_MARGINS_DP, this)
@@ -267,6 +271,7 @@ class GameActivity : BaseGameActivity() {
             LemuroidTouchConfigs.getRadialGamePadConfig(
                 touchControllerConfig.rightConfig,
                 hapticConfig,
+                hapticFeedbackStrength,
                 theme,
             )
         val rightPad = RadialGamePad(rightConfig, DEFAULT_MARGINS_DP, this)

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/settings/SettingsManager.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/settings/SettingsManager.kt
@@ -7,6 +7,7 @@ import com.swordfish.lemuroid.R
 import com.swordfish.lemuroid.app.shared.settings.HDModeQuality
 import com.swordfish.lemuroid.common.math.Fraction
 import com.swordfish.lemuroid.lib.storage.cache.CacheCleaner
+import com.swordfish.radialgamepad.library.haptics.HapticStrength
 import dagger.Lazy
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -21,6 +22,11 @@ class SettingsManager(private val context: Context, sharedPreferences: Lazy<Shar
     suspend fun autoSave() = booleanPreference(R.string.pref_key_autosave, true)
 
     suspend fun hapticFeedbackMode() = stringPreference(R.string.pref_key_haptic_feedback_mode, "press")
+
+    suspend fun hapticFeedbackStrength(): HapticStrength {
+        val value = kotlin.runCatching { HapticStrength.values()[intPreference(R.string.pref_key_haptic_feedback_strength, 1)] }
+        return value.getOrDefault(HapticStrength.MEDIUM)
+    }
 
     suspend fun lowLatencyAudio() = booleanPreference(R.string.pref_key_low_latency_audio, false)
 

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/settings/general/SettingsScreen.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/settings/general/SettingsScreen.kt
@@ -108,20 +108,32 @@ private fun MiscSettings(
 
 @Composable
 private fun InputSettings(navController: NavController) {
+    val feedbackPreference = indexPreferenceState(
+        R.string.pref_key_haptic_feedback_mode,
+        "press",
+        stringListResource(R.array.pref_key_haptic_feedback_mode_values),
+    )
+
     LemuroidCardSettingsGroup(
         title = { Text(text = stringResource(id = R.string.settings_category_input)) },
     ) {
         LemuroidSettingsList(
-            state =
-                indexPreferenceState(
-                    R.string.pref_key_haptic_feedback_mode,
-                    "press",
-                    stringListResource(R.array.pref_key_haptic_feedback_mode_values),
-                ),
+            state = feedbackPreference,
             title = {
                 Text(text = stringResource(id = R.string.settings_title_enable_touch_feedback))
             },
             items = stringListResource(R.array.pref_key_haptic_feedback_mode_display_names),
+        )
+        LemuroidSettingsSlider(
+            enabled = feedbackPreference.value != 0,
+            state = intPreferenceState(
+                key = stringResource(id = R.string.pref_key_haptic_feedback_strength),
+                default = 1,
+            ),
+            steps = 1,
+            valueRange = 0f..2f,
+            title = { Text(text = stringResource(R.string.settings_title_touch_feedback_strength)) },
+            subtitle = { Text(text = stringResource(R.string.settings_description_touch_feedback_strength)) },
         )
         LemuroidSettingsMenuLink(
             title = { Text(text = stringResource(id = R.string.settings_title_gamepad_settings)) },

--- a/lemuroid-app/src/main/res/values/keys.xml
+++ b/lemuroid-app/src/main/res/values/keys.xml
@@ -10,6 +10,7 @@
     <string name="pref_key_save_sync_force_refresh" translatable="false">save_sync_force_refresh</string>
     <string name="pref_key_reset_gamepad_bindings" translatable="false">reset_gamepad_bindings</string>
     <string name="pref_key_haptic_feedback_mode" translatable="false">haptic_feedback_mode</string>
+    <string name="pref_key_haptic_feedback_strength" translatable="false">haptic_feedback_strength</string>
     <string name="pref_key_tilt_sensitivity_index" translatable="false">tilt_sensitivity_index</string>
     <string name="pref_key_hd_mode_quality" translatable="false">hd_mode_quality</string>
     <string name="pref_key_autosave" translatable="false">autosave</string>

--- a/lemuroid-app/src/main/res/values/strings.xml
+++ b/lemuroid-app/src/main/res/values/strings.xml
@@ -28,7 +28,11 @@
     <string name="settings_category_misc">Miscellaneous</string>
     <string name="settings_title_enable_autosave">Autosave state</string>
     <string name="settings_description_enable_autosave">Save state when exiting via game menu</string>
+
     <string name="settings_title_enable_touch_feedback">Vibrate on touch</string>
+    <string name="settings_title_touch_feedback_strength">Vibration strength</string>
+    <string name="settings_description_touch_feedback_strength">Adjust the strength of the vibration</string>
+
     <string name="settings_title_tilt_sensitivity">Tilt sensor sensitivity</string>
     <string name="settings_title_hd_quality">HD mode quality</string>
     <string name="settings_title_maximum_cache_usage">Cache size limit</string>

--- a/lemuroid-touchinput/src/main/java/com/swordfish/touchinput/radial/LemuroidTouchConfigs.kt
+++ b/lemuroid-touchinput/src/main/java/com/swordfish/touchinput/radial/LemuroidTouchConfigs.kt
@@ -11,6 +11,7 @@ import com.swordfish.radialgamepad.library.config.RadialGamePadTheme
 import com.swordfish.radialgamepad.library.config.SecondaryDialConfig
 import com.swordfish.radialgamepad.library.event.GestureType
 import com.swordfish.radialgamepad.library.haptics.HapticConfig
+import com.swordfish.radialgamepad.library.haptics.HapticStrength
 import com.swordfish.touchinput.controller.R
 
 object LemuroidTouchConfigs {
@@ -72,6 +73,7 @@ object LemuroidTouchConfigs {
     fun getRadialGamePadConfig(
         kind: Kind,
         haptic: HapticConfig,
+        strength: HapticStrength,
         theme: RadialGamePadTheme,
     ): RadialGamePadConfig {
         val radialGamePadConfig =
@@ -135,6 +137,7 @@ object LemuroidTouchConfigs {
         return radialGamePadConfig.copy(
             haptic = haptic,
             preferScreenTouchCoordinates = useRawTouchCoordinates,
+            strength = strength
         )
     }
 


### PR DESCRIPTION
# Goal of the PR 

This PR introduces three strength level to the haptics.
Mostly because I went insane when trying to use play my gba games.

By default, the vibration settings correspond to what was present before

### Notes 
- Requires a future version of the radial gamepad library, see https://github.com/Swordfish90/RadialGamePad/pull/29