### PR TITLE
Implement viewport alignment

### DIFF
--- a/buildSrc/src/main/java/deps.kt
+++ b/buildSrc/src/main/java/deps.kt
@@ -23,7 +23,7 @@ object deps {
         const val serialization   = "1.2.2"
         const val fragment        = "1.5.1"
         const val activity        = "1.7.2"
-        const val libretrodroid   = "0.13.0"
+        const val libretrodroid   = "dev-SNAPSHOT"
         const val composeBom      = "2024.02.02"
         const val kotlinExtension = "1.4.6"
         const val padkit          = "1.0.0-beta1"
@@ -166,7 +166,7 @@ object deps {
         const val composeHtmlText          = "de.charlex.compose.material3:material3-html-text:2.0.0-beta01"
         const val collectionsImmutable     = "org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.8"
         const val padkit                   = "io.github.swordfish90:padkit:${versions.padkit}"
-        const val libretrodroid            = "com.github.Swordfish90:LibretroDroid:${versions.libretrodroid}"
+        const val libretrodroid            = "com.github.grantland:LibretroDroid:${versions.libretrodroid}"
     }
 
     object plugins {

--- a/lemuroid-app/src/main/AndroidManifest.xml
+++ b/lemuroid-app/src/main/AndroidManifest.xml
@@ -44,6 +44,10 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
 
         <activity

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/gamemenu/GameMenuHomeScreen.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/gamemenu/GameMenuHomeScreen.kt
@@ -21,7 +21,8 @@ import com.swordfish.lemuroid.app.shared.GameMenuContract
 import com.swordfish.lemuroid.app.utils.android.settings.LemuroidSettingsList
 import com.swordfish.lemuroid.app.utils.android.settings.LemuroidSettingsMenuLink
 import com.swordfish.lemuroid.app.utils.android.settings.LemuroidSettingsSwitch
-import timber.log.Timber
+import com.swordfish.lemuroid.app.utils.android.settings.indexPreferenceState
+import com.swordfish.lemuroid.app.utils.android.stringListResource
 import kotlin.reflect.KFunction1
 
 @Composable
@@ -140,6 +141,23 @@ fun GameMenuHomeScreen(
             onClick = {
                 onResult { putExtra(GameMenuContract.RESULT_EDIT_TOUCH_CONTROLS, true) }
             },
+        )
+
+        LemuroidSettingsList(
+            state =
+                indexPreferenceState(
+                    R.string.pref_key_viewport_alignment,
+                    "center",
+                    stringListResource(R.array.pref_key_viewport_alignment).toList(),
+                ),
+            title = { Text(text = stringResource(id = R.string.game_menu_viewport_alignment)) },
+            icon = {
+                Icon(
+                    painterResource(R.drawable.ic_menu_image),
+                    contentDescription = stringResource(id = R.string.game_menu_viewport_alignment),
+                )
+            },
+            items = stringListResource(R.array.pref_key_viewport_alignment_display_names),
         )
 
         if (gameMenuRequest.advancedCoreOptions.isNotEmpty() || gameMenuRequest.coreOptions.isNotEmpty()) {

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/settings/SettingsManager.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/settings/SettingsManager.kt
@@ -56,6 +56,8 @@ class SettingsManager(private val context: Context, sharedPreferences: Lazy<Shar
 
     suspend fun allowDirectGameLoad() = booleanPreference(R.string.pref_key_allow_direct_game_load, true)
 
+    suspend fun viewportAlignment() = stringPreference(R.string.pref_key_viewport_alignment, "center")
+
     private suspend fun booleanPreference(
         keyId: Int,
         default: Boolean,

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/game/viewmodel/GameViewModelRetroGameView.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/game/viewmodel/GameViewModelRetroGameView.kt
@@ -27,6 +27,7 @@ import com.swordfish.lemuroid.lib.storage.RomFiles
 import com.swordfish.libretrodroid.GLRetroView
 import com.swordfish.libretrodroid.GLRetroViewData
 import com.swordfish.libretrodroid.Variable
+import com.swordfish.libretrodroid.ViewportAlignment
 import com.swordfish.libretrodroid.VirtualFile
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -89,6 +90,7 @@ class GameViewModelRetroGameView(
         val filter = settingsManager.screenFilter()
         val hdMode = settingsManager.hdMode()
         val hdModeQuality = settingsManager.hdModeQuality()
+        val alignment = settingsManager.viewportAlignment()
         val lowLatencyAudio = settingsManager.lowLatencyAudio()
         val enableRumble = settingsManager.enableRumble()
         val directLoad = settingsManager.allowDirectGameLoad()
@@ -131,6 +133,7 @@ class GameViewModelRetroGameView(
                         hdMode,
                         hdModeQuality,
                         filter,
+                        alignment,
                         lowLatencyAudio,
                         enableRumble,
                         enableMicrophone,
@@ -199,6 +202,7 @@ class GameViewModelRetroGameView(
         hdMode: Boolean,
         hdModeQuality: HDModeQuality,
         screenFilter: String,
+        alignment: String,
         lowLatencyAudio: Boolean,
         requestRumble: Boolean,
         requestMicrophone: Boolean,
@@ -229,6 +233,11 @@ class GameViewModelRetroGameView(
                     screenFilter,
                     GameSystem.findById(gameData.game.systemId),
                 )
+            viewportAlignment = when (alignment) {
+                "top" -> ViewportAlignment.TOP
+                "bottom" -> ViewportAlignment.BOTTOM
+                else -> ViewportAlignment.CENTER
+            }
             preferLowLatencyAudio = lowLatencyAudio
             rumbleEventsEnabled = requestRumble
             skipDuplicateFrames = systemCoreConfig.skipDuplicateFrames
@@ -275,6 +284,10 @@ class GameViewModelRetroGameView(
         owner.launchOnState(Lifecycle.State.RESUMED) {
             initializeRumbleFlow()
         }
+
+        owner.launchOnState(Lifecycle.State.RESUMED) {
+            initializeViewportAlignment()
+        }
     }
 
     private suspend fun initializeCoreVariablesFlow() {
@@ -291,6 +304,16 @@ class GameViewModelRetroGameView(
         val retroGameView = retroGameViewFlow()
         val rumbleEvents = retroGameView.getRumbleEvents()
         rumbleManager.collectAndProcessRumbleEvents(systemCoreConfig, rumbleEvents)
+    }
+
+    private suspend fun initializeViewportAlignment() {
+        val retroGameView = retroGameViewFlow()
+        val viewportAlignment = settingsManager.viewportAlignment()
+        retroGameView.viewportAlignment = when (viewportAlignment) {
+            "top" -> ViewportAlignment.TOP
+            "bottom" -> ViewportAlignment.BOTTOM
+            else -> ViewportAlignment.CENTER
+        }
     }
 
     private suspend fun initializeRetroGameViewErrorsFlow() {

--- a/lemuroid-app/src/main/res/drawable/ic_menu_image.xml
+++ b/lemuroid-app/src/main/res/drawable/ic_menu_image.xml
@@ -1,5 +1,5 @@
-<vector android:height="96dp" android:tint="?attr/colorControlNormal"
+<vector android:height="24dp" android:tint="?attr/colorControlNormal"
     android:viewportHeight="24" android:viewportWidth="24"
-    android:width="96dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="@android:color/white" android:pathData="M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2zM8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z"/>
 </vector>

--- a/lemuroid-app/src/main/res/values/keys.xml
+++ b/lemuroid-app/src/main/res/values/keys.xml
@@ -28,6 +28,7 @@
 
     <string name="pref_key_shader_filter" translatable="false">shader_filter_0</string>
     <string name="pref_key_hd_mode" translatable="false">hd_mode</string>
+    <string name="pref_key_viewport_alignment" translatable="false">viewport_alignment</string>
 
     <string-array translatable="false" name="pref_key_haptic_feedback_mode_values">
         <item>none</item>
@@ -55,5 +56,17 @@
         <item>@string/shader_filter_names_smooth</item>
         <item>@string/shader_filter_names_crt</item>
         <item>@string/shader_filter_names_lcd</item>
+    </string-array>
+
+    <string-array translatable="false" name="pref_key_viewport_alignment">
+        <item>top</item>
+        <item>center</item>
+        <item>bottom</item>
+    </string-array>
+
+    <string-array translatable="false" name="pref_key_viewport_alignment_display_names">
+        <item>@string/shader_filter_viewport_alignment_top</item>
+        <item>@string/shader_filter_viewport_alignment_center</item>
+        <item>@string/shader_filter_viewport_alignment_bottom</item>
     </string-array>
 </resources>

--- a/lemuroid-app/src/main/res/values/strings.xml
+++ b/lemuroid-app/src/main/res/values/strings.xml
@@ -116,6 +116,7 @@
     <string name="game_menu_state">State %1$s</string>
     <string name="game_menu_change_disk_button">Change Disk</string>
     <string name="game_menu_edit_touch_controls">Edit Controls</string>
+    <string name="game_menu_viewport_alignment">Viewport Alignment</string>
     <string name="game_menu_mute_audio">Mute</string>
     <string name="game_menu_fast_forward">Fast-Forward</string>
     <string name="game_menu_change_disk_disk">Disk %1$s</string>
@@ -215,6 +216,10 @@
     <string name="shader_filter_names_smooth">Smooth</string>
     <string name="shader_filter_names_crt">CRT</string>
     <string name="shader_filter_names_lcd">LCD</string>
+
+    <string name="shader_filter_viewport_alignment_center">Center</string>
+    <string name="shader_filter_viewport_alignment_top">Top</string>
+    <string name="shader_filter_viewport_alignment_bottom">Bottom</string>
 
     <string name="haptic_feedback_mode_names_none">None</string>
     <string name="haptic_feedback_mode_names_press">Press</string>


### PR DESCRIPTION
Adds support for vertical alignment in the form of either CENTER (default), TOP, or BOTTOM. My goal here is to use TOP along with my 8BitDo Micro Clip.

Depends on https://github.com/Swordfish90/LibretroDroid/pull/119 and we can update this PR once that PR is merged and a new release is tagged.