### PR TITLE
feat: add fullscreen accessibility overlay to game screen

### DIFF
--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/game/MobileGameScreen.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/game/MobileGameScreen.kt
@@ -63,6 +63,10 @@ import com.swordfish.touchinput.radial.ui.LemuroidButtonPressFeedback
 import gg.padkit.PadKit
 import gg.padkit.config.HapticFeedbackType
 import gg.padkit.inputstate.InputState
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 
 @Composable
 fun MobileGameScreen(viewModel: BaseGameScreenViewModel) {
@@ -122,6 +126,7 @@ fun MobileGameScreen(viewModel: BaseGameScreenViewModel) {
             val fullScreenPosition = remember { mutableStateOf<Rect?>(null) }
             val viewportPosition = remember { mutableStateOf<Rect?>(null) }
 
+            val gameDisplayLabel = stringResource(com.swordfish.lemuroid.R.string.game_display_accessibility_label)
             AndroidView(
                 modifier =
                     Modifier
@@ -204,6 +209,17 @@ fun MobileGameScreen(viewModel: BaseGameScreenViewModel) {
                     }
                 }
             }
+
+            // Accessibility overlay to ensure the game display is always discoverable by TalkBack
+            // regardless of touch controls visibility.
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .semantics {
+                        contentDescription = gameDisplayLabel
+                        role = Role.Image
+                    }
+            )
         }
 
         val isLoading =

--- a/lemuroid-app/src/main/res/values/strings.xml
+++ b/lemuroid-app/src/main/res/values/strings.xml
@@ -152,6 +152,7 @@
     <string name="game_running_notification_title">%1$s is running</string>
     <string name="game_running_notification_title_alternative">Game is running</string>
     <string name="game_running_notification_message">Make sure to save your progress</string>
+    <string name="game_display_accessibility_label">Game Display</string>
 
     <string name="game_loader_error_gl_incompatible">This Core requires an OpenGL ES version which is not supported by your device.</string>
     <string name="game_loader_error_load_game">Something bad happened while loading your game. Make sure the ROM is supported by Lemuroid and rescan your games.</string>


### PR DESCRIPTION
## Overview

This PR adds a transparent, fullscreen accessibility element over the emulation game screen.

## The Problem

Currently, when a game is running in Lemuroid, screen readers like TalkBack have no focusable element on the actual game canvas. This prevents blind users from utilizing modern accessibility features, such as TalkBack's integration with Gemini/Google AI for image descriptions.

## The Solution

I have added a focusable Box element that spans the game screen. It is transparent and does not interfere with visual gameplay or touch controls, but it provides a focus anchor for TalkBack.

## Impact

With this element in place, a blind player can:

1.  Focus on the game screen using TalkBack.
2. Invoke "Describe Image" (via Gemini/TalkBack).
3. Receive a real-time AI-generated description of the game state (e.g., "A character in an orange suit is fighting on a grassy plain").

Note: The code changes were AI generated. I've tested heavily with PSP games and GBA, and it works. With this, I'm able to play Dragon Ball Z Tenkaichi TagTeam story mode, which I never would have been able to do without TalkBack's image descriptions.