### PR TITLE
Added the ability to set custom names and box art for games

### DIFF
--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/LemuroidApplicationModule.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/LemuroidApplicationModule.kt
@@ -136,7 +136,7 @@ abstract class LemuroidApplicationModule {
         fun retrogradeDb(app: LemuroidApplication) =
             Room.databaseBuilder(app, RetrogradeDatabase::class.java, RetrogradeDatabase.DB_NAME)
                 .addCallback(GameSearchDao.CALLBACK)
-                .addMigrations(GameSearchDao.MIGRATION, Migrations.VERSION_8_9)
+                .addMigrations(GameSearchDao.MIGRATION, Migrations.VERSION_8_9, Migrations.VERSION_9_10)
                 .fallbackToDestructiveMigration()
                 .build()
 

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/LemuroidApplicationModule.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/LemuroidApplicationModule.kt
@@ -50,6 +50,7 @@ import com.swordfish.lemuroid.lib.core.CoresSelection
 import com.swordfish.lemuroid.lib.game.GameLoader
 import com.swordfish.lemuroid.lib.injection.PerActivity
 import com.swordfish.lemuroid.lib.injection.PerApp
+import com.swordfish.lemuroid.lib.library.CustomCoverManager
 import com.swordfish.lemuroid.lib.library.LemuroidLibrary
 import com.swordfish.lemuroid.lib.library.db.RetrogradeDatabase
 import com.swordfish.lemuroid.lib.library.db.dao.GameSearchDao
@@ -125,6 +126,12 @@ abstract class LemuroidApplicationModule {
 
     @Module
     companion object {
+
+        @Provides
+        @PerApp
+        @JvmStatic
+        fun customCoverManager(context: Context) = CustomCoverManager(context)
+
         @Provides
         @PerApp
         @JvmStatic
@@ -177,7 +184,8 @@ abstract class LemuroidApplicationModule {
             storageProviderRegistry: Lazy<StorageProviderRegistry>,
             gameMetadataProvider: Lazy<GameMetadataProvider>,
             biosManager: BiosManager,
-        ) = LemuroidLibrary(db, storageProviderRegistry, gameMetadataProvider, biosManager)
+            customCoverManager: CustomCoverManager,
+        ) = LemuroidLibrary(db, storageProviderRegistry, gameMetadataProvider, biosManager, customCoverManager)
 
         @Provides
         @PerApp

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/LemuroidApplicationModule.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/LemuroidApplicationModule.kt
@@ -50,7 +50,7 @@ import com.swordfish.lemuroid.lib.core.CoresSelection
 import com.swordfish.lemuroid.lib.game.GameLoader
 import com.swordfish.lemuroid.lib.injection.PerActivity
 import com.swordfish.lemuroid.lib.injection.PerApp
-import com.swordfish.lemuroid.lib.library.CustomCoverManager
+import com.swordfish.lemuroid.lib.library.covers.CustomCoverManager
 import com.swordfish.lemuroid.lib.library.LemuroidLibrary
 import com.swordfish.lemuroid.lib.library.db.RetrogradeDatabase
 import com.swordfish.lemuroid.lib.library.db.dao.GameSearchDao

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/main/CustomNameDialog.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/main/CustomNameDialog.kt
@@ -1,0 +1,54 @@
+package com.swordfish.lemuroid.app.mobile.feature.main
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.swordfish.lemuroid.R
+
+
+@Composable
+fun CustomNameDialog(
+    initialName: String,
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit,
+) {
+    var text by remember { mutableStateOf(initialName) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(id = R.string.game_context_menu_custom_name_dialog_title)) },
+        text = {
+            OutlinedTextField(
+                value = text,
+                onValueChange = { text = it },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    if (text.isNotBlank()) {
+                        onConfirm(text.trim())
+                    }
+                },
+            ) {
+                Text("OK")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        },
+    )
+}

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/main/MainActivity.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/main/MainActivity.kt
@@ -63,6 +63,7 @@ import com.swordfish.lemuroid.lib.android.RetrogradeComponentActivity
 import com.swordfish.lemuroid.lib.bios.BiosManager
 import com.swordfish.lemuroid.lib.core.CoresSelection
 import com.swordfish.lemuroid.lib.injection.PerActivity
+import com.swordfish.lemuroid.lib.library.CustomCoverManager
 import com.swordfish.lemuroid.lib.library.MetaSystemID
 import com.swordfish.lemuroid.lib.library.SystemID
 import com.swordfish.lemuroid.lib.library.db.RetrogradeDatabase
@@ -426,7 +427,8 @@ class MainActivity : RetrogradeComponentActivity(), BusyActivity {
                 retrogradeDb: RetrogradeDatabase,
                 shortcutsGenerator: ShortcutsGenerator,
                 gameLauncher: GameLauncher,
-            ) = GameInteractor(activity, retrogradeDb, false, shortcutsGenerator, gameLauncher)
+                customCoverManager: CustomCoverManager,
+            ) = GameInteractor(activity, retrogradeDb, false, shortcutsGenerator, gameLauncher, customCoverManager)
         }
     }
 }

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/main/MainActivity.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/main/MainActivity.kt
@@ -355,6 +355,10 @@ class MainActivity : RetrogradeComponentActivity(), BusyActivity {
                     gameInteractor.onFavoriteToggle(game, isFavorite)
                 },
                 onCreateShortcut = { gameInteractor.onCreateShortcut(it) },
+                onSetCustomName = { game, name -> gameInteractor.onSetCustomName(game, name) },
+                onClearCustomName = { game -> gameInteractor.onClearCustomName(game) },
+                onSetCustomCoverUri = { game, uri -> gameInteractor.onSetCustomCoverUri(game, uri) },
+                onClearCustomCoverUri = { game -> gameInteractor.onClearCustomCoverUri(game) },
             )
 
             if (infoDialogDisplayed.value) {

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/main/MainActivity.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/main/MainActivity.kt
@@ -63,7 +63,7 @@ import com.swordfish.lemuroid.lib.android.RetrogradeComponentActivity
 import com.swordfish.lemuroid.lib.bios.BiosManager
 import com.swordfish.lemuroid.lib.core.CoresSelection
 import com.swordfish.lemuroid.lib.injection.PerActivity
-import com.swordfish.lemuroid.lib.library.CustomCoverManager
+import com.swordfish.lemuroid.lib.library.covers.CustomCoverManager
 import com.swordfish.lemuroid.lib.library.MetaSystemID
 import com.swordfish.lemuroid.lib.library.SystemID
 import com.swordfish.lemuroid.lib.library.db.RetrogradeDatabase

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/main/MainGameContextActions.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/main/MainGameContextActions.kt
@@ -1,5 +1,8 @@
 package com.swordfish.lemuroid.app.mobile.feature.main
 
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -18,27 +21,40 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeContent
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AppShortcut
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.RestartAlt
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.swordfish.lemuroid.R
@@ -55,6 +71,10 @@ fun MainGameContextActions(
     onGameRestart: (Game) -> Unit,
     onFavoriteToggle: (Game, Boolean) -> Unit,
     onCreateShortcut: (Game) -> Unit,
+    onSetCustomName: (Game, String) -> Unit,
+    onClearCustomName: (Game) -> Unit,
+    onSetCustomCoverUri: (Game, String) -> Unit,
+    onClearCustomCoverUri: (Game) -> Unit,
 ) {
     val modalSheetState = rememberModalBottomSheetState(true)
     val selectedGame = selectedGameState.value
@@ -80,6 +100,10 @@ fun MainGameContextActions(
                 onFavoriteToggle = onFavoriteToggle,
                 shortcutSupported = shortcutSupported,
                 onCreateShortcut = onCreateShortcut,
+                onSetCustomName = onSetCustomName,
+                onClearCustomName = onClearCustomName,
+                onSetCustomCoverUri = onSetCustomCoverUri,
+                onClearCustomCoverUri = onClearCustomCoverUri,
             )
         }
     }
@@ -94,11 +118,36 @@ private fun ContextActionContent(
     onFavoriteToggle: (Game, Boolean) -> Unit,
     shortcutSupported: Boolean,
     onCreateShortcut: (Game) -> Unit,
+    onSetCustomName: (Game, String) -> Unit,
+    onClearCustomName: (Game) -> Unit,
+    onSetCustomCoverUri: (Game, String) -> Unit,
+    onClearCustomCoverUri: (Game) -> Unit,
 ) {
+    val context = LocalContext.current
+    var showCustomNameDialog by remember { mutableStateOf(false) }
+
+    val imagePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent(),
+    ) { uri: Uri? ->
+        if (uri != null) {
+            try {
+                context.contentResolver.takePersistableUriPermission(
+                    uri,
+                    android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION,
+                )
+            } catch (_: SecurityException) {
+
+            }
+            onSetCustomCoverUri(selectedGame, uri.toString())
+            selectedGameState.value = null
+        }
+    }
+
     Column(
         modifier =
             Modifier
                 .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
                 .windowInsetsPadding(WindowInsets.safeContent.only(WindowInsetsSides.Bottom)),
     ) {
         ContextActionHeader(game = selectedGame)
@@ -150,7 +199,95 @@ private fun ContextActionContent(
                 },
             )
         }
+
+        if (selectedGame.customName != null) {
+            ContextActionEntry(
+                label = stringResource(id = R.string.game_context_menu_remove_custom_name),
+                icon = Icons.Default.Clear,
+                onClick = {
+                    onClearCustomName(selectedGame)
+                    selectedGameState.value = null
+                },
+            )
+        } else {
+            ContextActionEntry(
+                label = stringResource(id = R.string.game_context_menu_add_custom_name),
+                icon = Icons.Default.Edit,
+                onClick = {
+                    showCustomNameDialog = true
+                },
+            )
+        }
+
+        if (selectedGame.customCoverUri != null) {
+            ContextActionEntry(
+                label = stringResource(id = R.string.game_context_menu_remove_custom_artwork),
+                icon = Icons.Default.Clear,
+                onClick = {
+                    onClearCustomCoverUri(selectedGame)
+                    selectedGameState.value = null
+                },
+            )
+        } else {
+            ContextActionEntry(
+                label = stringResource(id = R.string.game_context_menu_add_custom_artwork),
+                icon = Icons.Default.Image,
+                onClick = {
+                    imagePickerLauncher.launch("image/*")
+                },
+            )
+        }
     }
+
+    if (showCustomNameDialog) {
+        CustomNameDialog(
+            initialName = selectedGame.fileName,
+            onDismiss = { showCustomNameDialog = false },
+            onConfirm = { newName ->
+                showCustomNameDialog = false
+                onSetCustomName(selectedGame, newName)
+                selectedGameState.value = null
+            },
+        )
+    }
+}
+
+@Composable
+private fun CustomNameDialog(
+    initialName: String,
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit,
+) {
+    var text by remember { mutableStateOf(initialName) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(id = R.string.game_context_menu_custom_name_dialog_title)) },
+        text = {
+            OutlinedTextField(
+                value = text,
+                onValueChange = { text = it },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    if (text.isNotBlank()) {
+                        onConfirm(text.trim())
+                    }
+                },
+            ) {
+                Text("OK")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        },
+    )
 }
 
 @Composable

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/main/MainGameContextActions.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/main/MainGameContextActions.kt
@@ -61,6 +61,7 @@ import com.swordfish.lemuroid.R
 import com.swordfish.lemuroid.app.mobile.shared.compose.ui.LemuroidGameTexts
 import com.swordfish.lemuroid.app.mobile.shared.compose.ui.LemuroidSmallGameImage
 import com.swordfish.lemuroid.lib.library.db.entity.Game
+import timber.log.Timber
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -135,8 +136,8 @@ private fun ContextActionContent(
                     uri,
                     android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION,
                 )
-            } catch (_: SecurityException) {
-
+            } catch (e: SecurityException) {
+                Timber.e(e, "Failed to persist read URI permission for custom cover")
             }
             onSetCustomCoverUri(selectedGame, uri.toString())
             selectedGameState.value = null
@@ -250,44 +251,6 @@ private fun ContextActionContent(
             },
         )
     }
-}
-
-@Composable
-private fun CustomNameDialog(
-    initialName: String,
-    onDismiss: () -> Unit,
-    onConfirm: (String) -> Unit,
-) {
-    var text by remember { mutableStateOf(initialName) }
-
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(text = stringResource(id = R.string.game_context_menu_custom_name_dialog_title)) },
-        text = {
-            OutlinedTextField(
-                value = text,
-                onValueChange = { text = it },
-                singleLine = true,
-                modifier = Modifier.fillMaxWidth(),
-            )
-        },
-        confirmButton = {
-            TextButton(
-                onClick = {
-                    if (text.isNotBlank()) {
-                        onConfirm(text.trim())
-                    }
-                },
-            ) {
-                Text("OK")
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text("Cancel")
-            }
-        },
-    )
 }
 
 @Composable

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/shortcuts/ShortcutsGenerator.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/shortcuts/ShortcutsGenerator.kt
@@ -7,6 +7,7 @@ import android.content.pm.ShortcutManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.drawable.Icon
+import android.net.Uri
 import android.os.Build
 import com.swordfish.lemuroid.app.shared.covers.CoverUtils
 import com.swordfish.lemuroid.app.shared.deeplink.DeepLink
@@ -38,8 +39,8 @@ class ShortcutsGenerator(
 
         val shortcutInfo =
             ShortcutInfo.Builder(appContext, "game_${game.id}")
-                .setShortLabel(game.title)
-                .setLongLabel(game.title)
+                .setShortLabel(game.displayName())
+                .setLongLabel(game.displayName())
                 .setIntent(DeepLink.launchIntentForGame(appContext, game))
                 .setIcon(Icon.createWithBitmap(bitmap))
                 .build()
@@ -51,8 +52,15 @@ class ShortcutsGenerator(
         withContext(Dispatchers.IO) {
             val result =
                 runCatching {
-                    val response = thumbnailsApi.downloadThumbnail(game.coverFrontUrl!!)
-                    BitmapFactory.decodeStream(response.body()).cropToSquare()
+                    // Prefer custom cover URI (local file) if set
+                    if (game.customCoverUri != null) {
+                        val uri = Uri.parse(game.customCoverUri)
+                        val inputStream = appContext.contentResolver.openInputStream(uri)
+                        BitmapFactory.decodeStream(inputStream).cropToSquare()
+                    } else {
+                        val response = thumbnailsApi.downloadThumbnail(game.coverFrontUrl!!)
+                        BitmapFactory.decodeStream(response.body()).cropToSquare()
+                    }
                 }
             result.getOrElse { retrieveFallbackBitmap(game) }
         }

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/shared/compose/ui/LemuroidGameImage.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/shared/compose/ui/LemuroidGameImage.kt
@@ -28,9 +28,9 @@ fun LemuroidGameImage(
     AsyncImage(
         model =
             ImageRequest.Builder(LocalContext.current)
-                .data(game.coverFrontUrl)
+                .data(game.displayCoverUrl())
                 .build(),
-        contentDescription = game.title,
+        contentDescription = game.displayName(),
         modifier =
             modifier
                 .fillMaxWidth()

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/shared/compose/ui/LemuroidSmallGameImage.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/shared/compose/ui/LemuroidSmallGameImage.kt
@@ -32,9 +32,9 @@ fun LemuroidSmallGameImage(
     AsyncImage(
         model =
             ImageRequest.Builder(LocalContext.current)
-                .data(game.coverFrontUrl)
+                .data(game.displayCoverUrl())
                 .build(),
-        contentDescription = game.title,
+        contentDescription = game.displayName(),
         modifier =
             modifier
                 .fillMaxWidth()

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/shared/compose/ui/LemuroidTexts.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/shared/compose/ui/LemuroidTexts.kt
@@ -24,7 +24,7 @@ fun LemuroidGameTexts(
             GameUtils.getGameSubtitle(context, game)
         }
 
-    LemuroidTexts(modifier, game.title, subtitle)
+    LemuroidTexts(modifier, game.displayName(), subtitle)
 }
 
 @Composable

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/GameContextMenuListener.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/GameContextMenuListener.kt
@@ -42,5 +42,27 @@ class GameContextMenuListener(
                 true
             }
         }
+
+        if (game.customName != null) {
+            menu.add(R.string.game_context_menu_remove_custom_name).setOnMenuItemClickListener {
+                gameInteractor.onClearCustomName(game)
+                true
+            }
+        } else {
+            menu.add(R.string.game_context_menu_add_custom_name).setOnMenuItemClickListener {
+                true
+            }
+        }
+
+        if (game.customCoverUri != null) {
+            menu.add(R.string.game_context_menu_remove_custom_artwork).setOnMenuItemClickListener {
+                gameInteractor.onClearCustomCoverUri(game)
+                true
+            }
+        } else {
+            menu.add(R.string.game_context_menu_add_custom_artwork).setOnMenuItemClickListener {
+                true
+            }
+        }
     }
 }

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/GameInteractor.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/GameInteractor.kt
@@ -60,6 +60,30 @@ class GameInteractor(
         return shortcutsGenerator.supportShortcuts()
     }
 
+    fun onSetCustomName(game: Game, customName: String) {
+        GlobalScope.launch {
+            retrogradeDb.gameDao().update(game.copy(customName = customName))
+        }
+    }
+
+    fun onClearCustomName(game: Game) {
+        GlobalScope.launch {
+            retrogradeDb.gameDao().update(game.copy(customName = null))
+        }
+    }
+
+    fun onSetCustomCoverUri(game: Game, uri: String) {
+        GlobalScope.launch {
+            retrogradeDb.gameDao().update(game.copy(customCoverUri = uri))
+        }
+    }
+
+    fun onClearCustomCoverUri(game: Game) {
+        GlobalScope.launch {
+            retrogradeDb.gameDao().update(game.copy(customCoverUri = null))
+        }
+    }
+
     private fun ensureNotificationsPermissionAvailable(): Boolean {
         if (useLeanback || Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
             return true

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/GameInteractor.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/GameInteractor.kt
@@ -2,6 +2,7 @@ package com.swordfish.lemuroid.app.shared
 
 import android.Manifest
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import androidx.core.content.ContextCompat
 import com.swordfish.lemuroid.R
@@ -9,6 +10,7 @@ import com.swordfish.lemuroid.app.mobile.feature.shortcuts.ShortcutsGenerator
 import com.swordfish.lemuroid.app.shared.game.GameLauncher
 import com.swordfish.lemuroid.app.shared.main.BusyActivity
 import com.swordfish.lemuroid.common.displayToast
+import com.swordfish.lemuroid.lib.library.CustomCoverManager
 import com.swordfish.lemuroid.lib.library.db.RetrogradeDatabase
 import com.swordfish.lemuroid.lib.library.db.entity.Game
 import kotlinx.coroutines.GlobalScope
@@ -20,6 +22,7 @@ class GameInteractor(
     private val useLeanback: Boolean,
     private val shortcutsGenerator: ShortcutsGenerator,
     private val gameLauncher: GameLauncher,
+    private val customCoverManager: CustomCoverManager,
 ) {
     fun onGamePlay(game: Game) {
         if (!ensureNotBusy()) {
@@ -72,14 +75,25 @@ class GameInteractor(
         }
     }
 
-    fun onSetCustomCoverUri(game: Game, uri: String) {
+    /**
+     * Copies the image at [sourceUri] into app-private storage, then stores
+     * the local file URI in the database.  This ensures the cover survives
+     * app restarts regardless of where the user picked the file from.
+     */
+    fun onSetCustomCoverUri(game: Game, sourceUri: String) {
         GlobalScope.launch {
-            retrogradeDb.gameDao().update(game.copy(customCoverUri = uri))
+            val localUri = customCoverManager.importCover(game.id, Uri.parse(sourceUri))
+            retrogradeDb.gameDao().update(game.copy(customCoverUri = localUri))
         }
     }
 
+    /**
+     * Removes the custom cover: deletes the file from private storage and
+     * clears the database field.
+     */
     fun onClearCustomCoverUri(game: Game) {
         GlobalScope.launch {
+            customCoverManager.deleteCover(game.id)
             retrogradeDb.gameDao().update(game.copy(customCoverUri = null))
         }
     }

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/GameInteractor.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/GameInteractor.kt
@@ -10,7 +10,7 @@ import com.swordfish.lemuroid.app.mobile.feature.shortcuts.ShortcutsGenerator
 import com.swordfish.lemuroid.app.shared.game.GameLauncher
 import com.swordfish.lemuroid.app.shared.main.BusyActivity
 import com.swordfish.lemuroid.common.displayToast
-import com.swordfish.lemuroid.lib.library.CustomCoverManager
+import com.swordfish.lemuroid.lib.library.covers.CustomCoverManager
 import com.swordfish.lemuroid.lib.library.db.RetrogradeDatabase
 import com.swordfish.lemuroid.lib.library.db.entity.Game
 import kotlinx.coroutines.GlobalScope

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/covers/CoverUtils.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/covers/CoverUtils.kt
@@ -21,7 +21,7 @@ object CoverUtils {
     ) {
         if (imageView == null) return
 
-        imageView.load(game.coverFrontUrl, imageView.context.imageLoader) {
+        imageView.load(game.displayCoverUrl(), imageView.context.imageLoader) {
             val fallbackDrawable = getFallbackDrawable(game)
             fallback(fallbackDrawable)
             error(fallbackDrawable)
@@ -64,14 +64,14 @@ object CoverUtils {
 
     private fun computeTitle(game: Game): String {
         val sanitizedName =
-            game.title
+            game.displayName()
                 .replace(Regex("\\(.*\\)"), "")
 
         return sanitizedName.asSequence()
             .filter { it.isDigit() or it.isUpperCase() or (it == '&') }
             .take(3)
             .joinToString("")
-            .ifBlank { game.title.first().toString() }
+            .ifBlank { game.displayName().first().toString() }
             .capitalize()
     }
 

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/tv/channel/ChannelHandler.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/tv/channel/ChannelHandler.kt
@@ -154,15 +154,16 @@ class ChannelHandler(
         val preview =
             PreviewProgram.Builder()
                 .setChannelId(channelId)
-                .setTitle(game.title)
+                .setTitle(game.displayName())
                 .setDescription(game.developer)
                 .setIntent(intent)
                 .setStartTimeUtcMillis(game.lastPlayedAt ?: 0)
                 .setType(TvContractCompat.PreviewPrograms.TYPE_GAME)
                 .setPosterArtAspectRatio(TvContractCompat.PreviewProgramColumns.ASPECT_RATIO_1_1)
 
-        if (game.coverFrontUrl != null && thumbnailExists) {
-            preview.setPosterArtUri(Uri.parse(game.coverFrontUrl))
+        val coverUrl = game.displayCoverUrl()
+        if (coverUrl != null && (game.customCoverUri != null || thumbnailExists)) {
+            preview.setPosterArtUri(Uri.parse(coverUrl))
         } else {
             preview.setPosterArtUri(Uri.parse(CoverUtils.getFallbackRemoteUrl(game)))
         }

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/tv/main/MainTVActivity.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/tv/main/MainTVActivity.kt
@@ -30,6 +30,7 @@ import com.swordfish.lemuroid.common.coroutines.safeCollect
 import com.swordfish.lemuroid.common.coroutines.safeLaunch
 import com.swordfish.lemuroid.lib.injection.PerActivity
 import com.swordfish.lemuroid.lib.injection.PerFragment
+import com.swordfish.lemuroid.lib.library.CustomCoverManager
 import com.swordfish.lemuroid.lib.library.db.RetrogradeDatabase
 import dagger.Provides
 import dagger.android.ContributesAndroidInjector
@@ -129,7 +130,8 @@ class MainTVActivity : BaseTVActivity(), BusyActivity {
                 retrogradeDb: RetrogradeDatabase,
                 shortcutsGenerator: ShortcutsGenerator,
                 gameLauncher: GameLauncher,
-            ) = GameInteractor(activity, retrogradeDb, true, shortcutsGenerator, gameLauncher)
+                customCoverManager: CustomCoverManager,
+            ) = GameInteractor(activity, retrogradeDb, true, shortcutsGenerator, gameLauncher, customCoverManager)
         }
     }
 }

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/tv/main/MainTVActivity.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/tv/main/MainTVActivity.kt
@@ -30,7 +30,7 @@ import com.swordfish.lemuroid.common.coroutines.safeCollect
 import com.swordfish.lemuroid.common.coroutines.safeLaunch
 import com.swordfish.lemuroid.lib.injection.PerActivity
 import com.swordfish.lemuroid.lib.injection.PerFragment
-import com.swordfish.lemuroid.lib.library.CustomCoverManager
+import com.swordfish.lemuroid.lib.library.covers.CustomCoverManager
 import com.swordfish.lemuroid.lib.library.db.RetrogradeDatabase
 import dagger.Provides
 import dagger.android.ContributesAndroidInjector

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/tv/shared/GamePresenter.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/tv/shared/GamePresenter.kt
@@ -6,7 +6,6 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.leanback.widget.ImageCardView
 import androidx.leanback.widget.Presenter
-import com.swordfish.lemuroid.R
 import com.swordfish.lemuroid.app.shared.GameContextMenuListener
 import com.swordfish.lemuroid.app.shared.GameInteractor
 import com.swordfish.lemuroid.app.shared.covers.CoverUtils
@@ -23,7 +22,7 @@ class GamePresenter(
     ) {
         if (item == null || viewHolder !is ViewHolder) return
         val game = item as Game
-        viewHolder.mCardView.titleText = game.title
+        viewHolder.mCardView.titleText = game.displayName()
         viewHolder.mCardView.contentText = GameUtils.getGameSubtitle(viewHolder.mCardView.context, game)
         viewHolder.mCardView.setMainImageDimensions(cardSize, cardSize)
         viewHolder.updateCardViewImage(game)

--- a/lemuroid-app/src/main/res/values/strings.xml
+++ b/lemuroid-app/src/main/res/values/strings.xml
@@ -97,6 +97,12 @@
     <string name="game_context_menu_restart">Restart</string>
     <string name="game_context_menu_create_shortcut">Pin to launcher</string>
 
+    <string name="game_context_menu_add_custom_name">Add custom name</string>
+    <string name="game_context_menu_remove_custom_name">Remove custom name</string>
+    <string name="game_context_menu_add_custom_artwork">Add custom artwork</string>
+    <string name="game_context_menu_remove_custom_artwork">Remove custom artwork</string>
+    <string name="game_context_menu_custom_name_dialog_title">Set custom name</string>
+
     <string name="home_notification_title">Enable notifications</string>
     <string name="home_notification_message">Lemuroid uses notifications to let you know when a game or operation is running in background.</string>
     <string name="home_notification_action">Enable</string>

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/CustomCoverManager.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/CustomCoverManager.kt
@@ -2,6 +2,7 @@ package com.swordfish.lemuroid.lib.library
 
 import android.content.Context
 import android.net.Uri
+import android.webkit.MimeTypeMap
 import com.swordfish.lemuroid.lib.library.db.entity.Game
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -19,17 +20,40 @@ import java.io.FileOutputStream
  */
 class CustomCoverManager(private val appContext: Context) {
 
+    /** Returns (and creates if necessary) the directory for custom covers. */
     fun getCoversDirectory(): File =
         File(appContext.getExternalFilesDir(null), "custom-covers").apply {
             mkdirs()
         }
 
-    private fun coverFileForGame(gameId: Int): File =
-        File(getCoversDirectory(), "cover_$gameId.png")
+    /**
+     * Resolves a file extension from the source URI's MIME type.
+     * Falls back to "png" if the type can't be determined.
+     */
+    private fun extensionForUri(sourceUri: Uri): String {
+        val mimeType = appContext.contentResolver.getType(sourceUri)
+        val ext = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType)
+        return ext ?: "png"
+    }
 
+    /** Build the cover file path for a given game id and extension. */
+    private fun coverFileForGame(gameId: Int, extension: String): File =
+        File(getCoversDirectory(), "cover_$gameId.$extension")
+
+    /**
+     * Copies the image at [sourceUri] into private storage and returns the local
+     * file:// URI string that should be persisted in [Game.customCoverUri].
+     *
+     * Any previously stored cover for this game is deleted first so that
+     * switching from e.g. a .jpg to a .webp doesn't leave an orphan.
+     */
     suspend fun importCover(gameId: Int, sourceUri: Uri): String =
         withContext(Dispatchers.IO) {
-            val destFile = coverFileForGame(gameId)
+            // Remove any existing cover regardless of its extension
+            deleteCoversForGameId(gameId)
+
+            val ext = extensionForUri(sourceUri)
+            val destFile = coverFileForGame(gameId, ext)
             appContext.contentResolver.openInputStream(sourceUri)?.use { input ->
                 FileOutputStream(destFile).use { output ->
                     input.copyTo(output)
@@ -38,19 +62,31 @@ class CustomCoverManager(private val appContext: Context) {
             Uri.fromFile(destFile).toString()
         }
 
+    /** Deletes the locally-stored cover for [gameId], regardless of extension. */
     fun deleteCover(gameId: Int) {
-        val file = coverFileForGame(gameId)
-        if (file.exists()) {
-            val deleted = file.delete()
-            Timber.d("Deleted custom cover for game $gameId: $deleted")
-        }
+        deleteCoversForGameId(gameId)
     }
 
+    /** Batch-deletes covers for a list of games. Called during library cleanup. */
     fun deleteCoversForGames(games: List<Game>) {
         games.forEach { game ->
             if (game.customCoverUri != null) {
-                deleteCover(game.id)
+                deleteCoversForGameId(game.id)
             }
         }
+    }
+
+    /**
+     * Deletes any file matching cover_<gameId>.* in the covers directory.
+     * This ensures cleanup works regardless of which image format was used.
+     */
+    private fun deleteCoversForGameId(gameId: Int) {
+        val prefix = "cover_${gameId}."
+        getCoversDirectory().listFiles()
+            ?.filter { it.name.startsWith(prefix) }
+            ?.forEach { file ->
+                val deleted = file.delete()
+                Timber.d("Deleted custom cover ${file.name}: $deleted")
+            }
     }
 }

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/CustomCoverManager.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/CustomCoverManager.kt
@@ -1,0 +1,56 @@
+package com.swordfish.lemuroid.lib.library
+
+import android.content.Context
+import android.net.Uri
+import com.swordfish.lemuroid.lib.library.db.entity.Game
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Manages custom cover artwork files stored in the app's private external storage.
+ *
+ * Images are copied into [getCoversDirectory] with a deterministic filename based on the
+ * game's database id so that:
+ *   - The URI never expires (it's a local file we own).
+ *   - Cleanup is trivial: delete the file when the game or the custom artwork is removed.
+ */
+class CustomCoverManager(private val appContext: Context) {
+
+    fun getCoversDirectory(): File =
+        File(appContext.getExternalFilesDir(null), "custom-covers").apply {
+            mkdirs()
+        }
+
+    private fun coverFileForGame(gameId: Int): File =
+        File(getCoversDirectory(), "cover_$gameId.png")
+
+    suspend fun importCover(gameId: Int, sourceUri: Uri): String =
+        withContext(Dispatchers.IO) {
+            val destFile = coverFileForGame(gameId)
+            appContext.contentResolver.openInputStream(sourceUri)?.use { input ->
+                FileOutputStream(destFile).use { output ->
+                    input.copyTo(output)
+                }
+            } ?: throw IllegalStateException("Cannot open input stream for $sourceUri")
+            Uri.fromFile(destFile).toString()
+        }
+
+    fun deleteCover(gameId: Int) {
+        val file = coverFileForGame(gameId)
+        if (file.exists()) {
+            val deleted = file.delete()
+            Timber.d("Deleted custom cover for game $gameId: $deleted")
+        }
+    }
+
+    fun deleteCoversForGames(games: List<Game>) {
+        games.forEach { game ->
+            if (game.customCoverUri != null) {
+                deleteCover(game.id)
+            }
+        }
+    }
+}

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/LemuroidLibrary.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/LemuroidLibrary.kt
@@ -49,6 +49,7 @@ class LemuroidLibrary(
     private val storageProviderRegistry: Lazy<StorageProviderRegistry>,
     private val gameMetadataProvider: Lazy<GameMetadataProvider>,
     private val biosManager: BiosManager,
+    private val customCoverManager: CustomCoverManager,
 ) {
     suspend fun indexLibrary() {
         val startedAtMs = System.currentTimeMillis()
@@ -315,6 +316,10 @@ class LemuroidLibrary(
     private fun removeDeletedGames(startedAtMs: Long) {
         Timber.d("Deleting games from db before: $startedAtMs")
         val games = retrogradedb.gameDao().selectByLastIndexedAtLessThan(startedAtMs)
+
+        // Clean up custom cover files before removing the database rows
+        customCoverManager.deleteCoversForGames(games)
+
         retrogradedb.gameDao().delete(games)
     }
 

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/LemuroidLibrary.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/LemuroidLibrary.kt
@@ -21,6 +21,7 @@ package com.swordfish.lemuroid.lib.library
 
 import com.swordfish.lemuroid.common.coroutines.batchWithSizeAndTime
 import com.swordfish.lemuroid.lib.bios.BiosManager
+import com.swordfish.lemuroid.lib.library.covers.CustomCoverManager
 import com.swordfish.lemuroid.lib.library.db.RetrogradeDatabase
 import com.swordfish.lemuroid.lib.library.db.entity.DataFile
 import com.swordfish.lemuroid.lib.library.db.entity.Game
@@ -57,7 +58,7 @@ class LemuroidLibrary(
         try {
             indexProviders(startedAtMs)
         } catch (e: Throwable) {
-            Timber.e("Library indexing stopped due to exception", e)
+            Timber.e(e, "Library indexing stopped due to exception")
         } finally {
             cleanUp(startedAtMs)
         }

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/covers/CustomCoverManager.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/covers/CustomCoverManager.kt
@@ -1,4 +1,4 @@
-package com.swordfish.lemuroid.lib.library
+package com.swordfish.lemuroid.lib.library.covers
 
 import android.content.Context
 import android.net.Uri

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/db/RetrogradeDatabase.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/db/RetrogradeDatabase.kt
@@ -29,7 +29,7 @@ import com.swordfish.lemuroid.lib.library.db.entity.Game
 
 @Database(
     entities = [Game::class, DataFile::class],
-    version = 9,
+    version = 10,
     exportSchema = true,
 )
 abstract class RetrogradeDatabase : RoomDatabase() {

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/db/dao/GameDao.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/db/dao/GameDao.kt
@@ -39,7 +39,7 @@ interface GameDao {
     @Query("SELECT * FROM games WHERE lastIndexedAt < :lastIndexedAt")
     fun selectByLastIndexedAtLessThan(lastIndexedAt: Long): List<Game>
 
-    @Query("SELECT * FROM games WHERE isFavorite = 1 ORDER BY title ASC")
+    @Query("SELECT * FROM games WHERE isFavorite = 1 ORDER BY COALESCE(customName, title) ASC")
     fun selectFavorites(): PagingSource<Int, Game>
 
     @Query(
@@ -61,10 +61,10 @@ interface GameDao {
     @Query("SELECT * FROM games WHERE lastPlayedAt IS NULL LIMIT :limit")
     fun selectFirstNotPlayed(limit: Int): Flow<List<Game>>
 
-    @Query("SELECT * FROM games WHERE systemId = :systemId ORDER BY title ASC, id DESC")
+    @Query("SELECT * FROM games WHERE systemId = :systemId ORDER BY COALESCE(customName, title) ASC, id DESC")
     fun selectBySystem(systemId: String): PagingSource<Int, Game>
 
-    @Query("SELECT * FROM games WHERE systemId IN (:systemIds) ORDER BY title ASC, id DESC")
+    @Query("SELECT * FROM games WHERE systemId IN (:systemIds) ORDER BY COALESCE(customName, title) ASC, id DESC")
     fun selectBySystems(systemIds: List<String>): PagingSource<Int, Game>
 
     @Query("SELECT DISTINCT systemId FROM games ORDER BY systemId ASC")

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/db/dao/GameSearchDao.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/db/dao/GameSearchDao.kt
@@ -45,20 +45,20 @@ class GameSearchDao(private val internalDao: Internal) {
             database.execSQL(
                 """
                 CREATE TRIGGER games_au AFTER UPDATE ON games BEGIN
-                  INSERT INTO fts_games(docid, title) VALUES(new.id, new.title);
+                  INSERT INTO fts_games(docid, title) VALUES(new.id, COALESCE(new.customName, new.title));
                 END;
                 """,
             )
             database.execSQL(
                 """
                 CREATE TRIGGER games_ai AFTER INSERT ON games BEGIN
-                  INSERT INTO fts_games(docid, title) VALUES(new.id, new.title);
+                  INSERT INTO fts_games(docid, title) VALUES(new.id, COALESCE(new.customName, new.title));
                 END;
                 """,
             )
             database.execSQL(
                 """
-                INSERT INTO fts_games(docid, title) SELECT id, title FROM games;
+                INSERT INTO fts_games(docid, title) SELECT id, COALESCE(customName, title) FROM games;
                 """,
             )
         }

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/db/dao/GameSearchDao.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/db/dao/GameSearchDao.kt
@@ -64,6 +64,54 @@ class GameSearchDao(private val internalDao: Internal) {
         }
     }
 
+    companion object {
+        internal fun migrateFtsForVersion10(database: SupportSQLiteDatabase) {
+            database.execSQL("DROP TRIGGER IF EXISTS games_bu")
+            database.execSQL("DROP TRIGGER IF EXISTS games_bd")
+            database.execSQL("DROP TRIGGER IF EXISTS games_au")
+            database.execSQL("DROP TRIGGER IF EXISTS games_ai")
+
+            database.execSQL(
+                """
+                CREATE TRIGGER games_bu BEFORE UPDATE ON games BEGIN
+                  DELETE FROM fts_games WHERE docid = old.id;
+                END;
+                """.trimIndent(),
+            )
+            database.execSQL(
+                """
+                CREATE TRIGGER games_bd BEFORE DELETE ON games BEGIN
+                  DELETE FROM fts_games WHERE docid = old.id;
+                END;
+                """.trimIndent(),
+            )
+            database.execSQL(
+                """
+                CREATE TRIGGER games_au AFTER UPDATE ON games BEGIN
+                  INSERT INTO fts_games(docid, title)
+                  VALUES(new.id, COALESCE(new.customName, new.title));
+                END;
+                """.trimIndent(),
+            )
+            database.execSQL(
+                """
+                CREATE TRIGGER games_ai AFTER INSERT ON games BEGIN
+                  INSERT INTO fts_games(docid, title)
+                  VALUES(new.id, COALESCE(new.customName, new.title));
+                END;
+                """.trimIndent(),
+            )
+
+            database.execSQL("DELETE FROM fts_games")
+            database.execSQL(
+                """
+                INSERT INTO fts_games(docid, title)
+                SELECT id, COALESCE(customName, title) FROM games
+                """.trimIndent(),
+            )
+        }
+    }
+
     fun search(query: String): PagingSource<Int, Game> =
         internalDao.rawSearch(
             SimpleSQLiteQuery(

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/db/dao/Migrations.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/db/dao/Migrations.kt
@@ -45,4 +45,55 @@ object Migrations {
                 )
             }
         }
+
+    val VERSION_9_10: Migration =
+        object : Migration(9, 10) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "ALTER TABLE games ADD COLUMN customName TEXT DEFAULT NULL",
+                )
+                database.execSQL(
+                    "ALTER TABLE games ADD COLUMN customCoverUri TEXT DEFAULT NULL",
+                )
+
+                database.execSQL("DROP TRIGGER IF EXISTS games_bu")
+                database.execSQL("DROP TRIGGER IF EXISTS games_bd")
+                database.execSQL("DROP TRIGGER IF EXISTS games_au")
+                database.execSQL("DROP TRIGGER IF EXISTS games_ai")
+
+                database.execSQL(
+                    """
+                    CREATE TRIGGER games_bu BEFORE UPDATE ON games BEGIN
+                      DELETE FROM fts_games WHERE docid=old.id;
+                    END;
+                    """.trimIndent(),
+                )
+                database.execSQL(
+                    """
+                    CREATE TRIGGER games_bd BEFORE DELETE ON games BEGIN
+                      DELETE FROM fts_games WHERE docid=old.id;
+                    END;
+                    """.trimIndent(),
+                )
+                database.execSQL(
+                    """
+                    CREATE TRIGGER games_au AFTER UPDATE ON games BEGIN
+                      INSERT INTO fts_games(docid, title) VALUES(new.id, COALESCE(new.customName, new.title));
+                    END;
+                    """.trimIndent(),
+                )
+                database.execSQL(
+                    """
+                    CREATE TRIGGER games_ai AFTER INSERT ON games BEGIN
+                      INSERT INTO fts_games(docid, title) VALUES(new.id, COALESCE(new.customName, new.title));
+                    END;
+                    """.trimIndent(),
+                )
+
+                database.execSQL("DELETE FROM fts_games")
+                database.execSQL(
+                    "INSERT INTO fts_games(docid, title) SELECT id, COALESCE(customName, title) FROM games",
+                )
+            }
+        }
 }

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/db/dao/Migrations.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/db/dao/Migrations.kt
@@ -49,51 +49,19 @@ object Migrations {
     val VERSION_9_10: Migration =
         object : Migration(9, 10) {
             override fun migrate(database: SupportSQLiteDatabase) {
-                database.execSQL(
-                    "ALTER TABLE games ADD COLUMN customName TEXT DEFAULT NULL",
-                )
-                database.execSQL(
-                    "ALTER TABLE games ADD COLUMN customCoverUri TEXT DEFAULT NULL",
-                )
-
-                database.execSQL("DROP TRIGGER IF EXISTS games_bu")
-                database.execSQL("DROP TRIGGER IF EXISTS games_bd")
-                database.execSQL("DROP TRIGGER IF EXISTS games_au")
-                database.execSQL("DROP TRIGGER IF EXISTS games_ai")
-
-                database.execSQL(
-                    """
-                    CREATE TRIGGER games_bu BEFORE UPDATE ON games BEGIN
-                      DELETE FROM fts_games WHERE docid=old.id;
-                    END;
-                    """.trimIndent(),
-                )
-                database.execSQL(
-                    """
-                    CREATE TRIGGER games_bd BEFORE DELETE ON games BEGIN
-                      DELETE FROM fts_games WHERE docid=old.id;
-                    END;
-                    """.trimIndent(),
-                )
-                database.execSQL(
-                    """
-                    CREATE TRIGGER games_au AFTER UPDATE ON games BEGIN
-                      INSERT INTO fts_games(docid, title) VALUES(new.id, COALESCE(new.customName, new.title));
-                    END;
-                    """.trimIndent(),
-                )
-                database.execSQL(
-                    """
-                    CREATE TRIGGER games_ai AFTER INSERT ON games BEGIN
-                      INSERT INTO fts_games(docid, title) VALUES(new.id, COALESCE(new.customName, new.title));
-                    END;
-                    """.trimIndent(),
-                )
-
-                database.execSQL("DELETE FROM fts_games")
-                database.execSQL(
-                    "INSERT INTO fts_games(docid, title) SELECT id, COALESCE(customName, title) FROM games",
-                )
+                migrateGamesTableToVersion10(database)
+                GameSearchDao.migrateFtsForVersion10(database)
             }
         }
+
+    private fun migrateGamesTableToVersion10(
+        database: SupportSQLiteDatabase,
+    ) {
+        database.execSQL(
+            "ALTER TABLE games ADD COLUMN customName TEXT DEFAULT NULL",
+        )
+        database.execSQL(
+            "ALTER TABLE games ADD COLUMN customCoverUri TEXT DEFAULT NULL",
+        )
+    }
 }

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/db/entity/Game.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/db/entity/Game.kt
@@ -49,7 +49,13 @@ data class Game(
     val lastIndexedAt: Long,
     val lastPlayedAt: Long? = null,
     val isFavorite: Boolean = false,
+    val customName: String? = null,
+    val customCoverUri: String? = null,
 ) : Serializable {
+
+    fun displayName(): String = customName ?: title
+    fun displayCoverUrl(): String? = customCoverUri ?: coverFrontUrl
+
     companion object {
         val DIFF_CALLBACK =
             object : DiffUtil.ItemCallback<Game>() {


### PR DESCRIPTION
Added the ability to set games with a custom name and a custom image perfect for ROM hacks where they have no official artwork.

The names often have version numbers that you want to keep on the file but may want to trim the version numbers out of the name shown in this app.
| Before | After |
|--------|--------|
| ![Before](https://github.com/user-attachments/assets/e7510345-9962-446a-a179-b9d5e4514a2f) | ![After](https://github.com/user-attachments/assets/1de40b7d-fb18-4c08-9015-6fdc089f5574) |


### How the changes work
There are two new options:
 - Add custom name
 - Add custom artwork

If the ROM already has a custom name or artwork then these will be replaced with Remove variants of the buttons

| New menu items | Prefilled name changer | new menu items are changed to remove variants |
|----------|----------|----------|
| ![Image1](https://github.com/user-attachments/assets/acc6a34e-18b6-4174-9c42-b99c8d0e085a) | ![Image2](https://github.com/user-attachments/assets/acf41048-3f3f-4e65-b52d-7f3e3b5f8cc1) | ![Image3](https://github.com/user-attachments/assets/be594b85-4079-4c23-98c4-ab28c6c64aba) |

## Related Issues
https://github.com/Swordfish90/Lemuroid/issues/36
https://github.com/Swordfish90/Lemuroid/issues/209
https://github.com/Swordfish90/Lemuroid/issues/609
 