### PR TITLE
Add SNES port 1 to match libretro snes9x's 2-port default

### DIFF
--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/GameSystem.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/GameSystem.kt
@@ -133,6 +133,7 @@ data class GameSystem(
                             controllerConfigs =
                                 hashMapOf(
                                     0 to arrayListOf(ControllerConfigs.SNES),
+                                    1 to arrayListOf(ControllerConfigs.SNES),
                                 ),
                         ),
                     ),


### PR DESCRIPTION
This makes the joystick usable for the second controller.

I use 8bitsdo Lite 2 controllers