### PR TITLE
Add Firestick support

### DIFF
--- a/lemuroid-app/src/main/AndroidManifest.xml
+++ b/lemuroid-app/src/main/AndroidManifest.xml
@@ -19,12 +19,19 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="com.android.providers.tv.permission.WRITE_EPG_DATA" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.OPEN_DOCUMENT_TREE" />
+        </intent>
+    </queries>
 
     <application
         android:name="com.swordfish.lemuroid.app.LemuroidApplication"

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/input/inputclass/InputClass.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/input/inputclass/InputClass.kt
@@ -2,6 +2,8 @@ package com.swordfish.lemuroid.app.shared.input.inputclass
 
 import android.view.InputDevice
 import com.swordfish.lemuroid.app.shared.input.InputKey
+import com.swordfish.lemuroid.app.shared.input.lemuroiddevice.LemuroidInputDeviceRemote
+import com.swordfish.lemuroid.app.shared.input.lemuroiddevice.getLemuroidInputDevice
 
 interface InputClass {
     fun getInputKeys(): Set<InputKey>
@@ -12,6 +14,8 @@ interface InputClass {
 fun InputDevice?.getInputClass(): InputClass {
     return when {
         this == null -> InputClassUnknown
+        (sources and InputDevice.SOURCE_DPAD) == InputDevice.SOURCE_DPAD && keyboardType == InputDevice.KEYBOARD_TYPE_NON_ALPHABETIC
+            -> InputClassRemote
         (sources and InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD -> InputClassGamePad
         (sources and InputDevice.SOURCE_KEYBOARD) == InputDevice.SOURCE_KEYBOARD -> InputClassKeyboard
         else -> InputClassUnknown

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/input/inputclass/InputClassRemote.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/input/inputclass/InputClassRemote.kt
@@ -1,0 +1,29 @@
+package com.swordfish.lemuroid.app.shared.input.inputclass
+
+import android.view.KeyEvent
+import android.view.MotionEvent
+import com.swordfish.lemuroid.app.shared.input.InputKey
+import com.swordfish.lemuroid.app.shared.input.inputKeySetOf
+
+object InputClassRemote : InputClass {
+    override fun getInputKeys(): Set<InputKey> {
+        return INPUT_KEYS
+    }
+
+    override fun getAxesMap(): Map<Int, Int> {
+        return emptyMap()
+    }
+
+    private val INPUT_KEYS =
+        inputKeySetOf(
+            KeyEvent.KEYCODE_DPAD_DOWN,
+            KeyEvent.KEYCODE_DPAD_UP,
+            KeyEvent.KEYCODE_DPAD_RIGHT,
+            KeyEvent.KEYCODE_DPAD_LEFT,
+            KeyEvent.KEYCODE_DPAD_CENTER,
+            KeyEvent.KEYCODE_MENU,
+            KeyEvent.KEYCODE_MEDIA_FAST_FORWARD,
+            KeyEvent.KEYCODE_MEDIA_REWIND,
+            KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE,
+        )
+}

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/input/lemuroiddevice/LemuroidInputDevice.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/input/lemuroiddevice/LemuroidInputDevice.kt
@@ -21,6 +21,8 @@ interface LemuroidInputDevice {
 fun InputDevice?.getLemuroidInputDevice(): LemuroidInputDevice {
     return when {
         this == null -> LemuroidInputDeviceUnknown
+        (sources and InputDevice.SOURCE_DPAD) == InputDevice.SOURCE_DPAD && keyboardType == InputDevice.KEYBOARD_TYPE_NON_ALPHABETIC
+             -> LemuroidInputDeviceRemote(this)
         (sources and InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD -> LemuroidInputDeviceGamePad(this)
         (sources and InputDevice.SOURCE_KEYBOARD) == InputDevice.SOURCE_KEYBOARD -> LemuroidInputDeviceKeyboard(this)
         else -> LemuroidInputDeviceUnknown

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/input/lemuroiddevice/LemuroidInputDeviceRemote.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/input/lemuroiddevice/LemuroidInputDeviceRemote.kt
@@ -1,0 +1,59 @@
+package com.swordfish.lemuroid.app.shared.input.lemuroiddevice
+
+import android.content.Context
+import android.view.InputDevice
+import android.view.KeyEvent
+import com.swordfish.lemuroid.app.shared.input.InputDeviceManager
+import com.swordfish.lemuroid.app.shared.input.RetroKey
+import com.swordfish.lemuroid.app.shared.input.bindingsOf
+import com.swordfish.lemuroid.app.shared.input.inputKeysOf
+import com.swordfish.lemuroid.app.shared.input.supportsAllKeys
+import com.swordfish.lemuroid.app.shared.settings.GameShortcutType
+
+class LemuroidInputDeviceRemote(private val device: InputDevice) : LemuroidInputDevice {
+    override fun getCustomizableKeys(): List<RetroKey> = InputDeviceManager.OUTPUT_KEYS
+
+    override fun getDefaultBindings() = DEFAULT_BINDINGS
+
+    override fun isEnabledByDefault(appContext: Context): Boolean {
+        return device.supportsAllKeys(MINIMAL_SUPPORTED_KEYS)
+    }
+
+    override fun getSupportedShortcuts(): List<GameShortcutType> = emptyList()
+
+    override fun isSupported(): Boolean {
+        return sequenceOf(
+            (device.sources and InputDevice.SOURCE_DPAD) == InputDevice.SOURCE_DPAD,
+            device.supportsAllKeys(MINIMAL_SUPPORTED_KEYS),
+            device.isVirtual.not(),
+        ).all { it }
+    }
+
+    companion object {
+        private val MINIMAL_SUPPORTED_KEYS =
+            inputKeysOf(
+                KeyEvent.KEYCODE_DPAD_UP,
+                KeyEvent.KEYCODE_DPAD_DOWN,
+                KeyEvent.KEYCODE_DPAD_LEFT,
+                KeyEvent.KEYCODE_DPAD_RIGHT,
+                KeyEvent.KEYCODE_DPAD_CENTER,
+                KeyEvent.KEYCODE_MENU,
+                KeyEvent.KEYCODE_MEDIA_FAST_FORWARD,
+                KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE,
+                KeyEvent.KEYCODE_MEDIA_REWIND,
+            )
+
+        private val DEFAULT_BINDINGS =
+            bindingsOf(
+                KeyEvent.KEYCODE_DPAD_UP to KeyEvent.KEYCODE_DPAD_LEFT,
+                KeyEvent.KEYCODE_DPAD_DOWN to KeyEvent.KEYCODE_DPAD_RIGHT,
+                KeyEvent.KEYCODE_DPAD_LEFT to KeyEvent.KEYCODE_DPAD_DOWN,
+                KeyEvent.KEYCODE_DPAD_RIGHT to KeyEvent.KEYCODE_DPAD_UP,
+                KeyEvent.KEYCODE_DPAD_CENTER to KeyEvent.KEYCODE_BUTTON_START,
+                KeyEvent.KEYCODE_MENU to KeyEvent.KEYCODE_BUTTON_X,
+                KeyEvent.KEYCODE_MEDIA_FAST_FORWARD to KeyEvent.KEYCODE_BUTTON_Y,
+                KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE to KeyEvent.KEYCODE_BUTTON_A,
+                KeyEvent.KEYCODE_MEDIA_REWIND  to KeyEvent.KEYCODE_BUTTON_B,
+            )
+    }
+}

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/tv/main/MainTVActivity.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/tv/main/MainTVActivity.kt
@@ -4,7 +4,10 @@ import android.Manifest
 import android.app.Activity
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
+import android.os.Environment
+import android.provider.Settings
 import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
@@ -36,6 +39,7 @@ import dagger.android.ContributesAndroidInjector
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import javax.inject.Inject
+import androidx.core.net.toUri
 
 @OptIn(DelicateCoroutinesApi::class)
 class MainTVActivity : BaseTVActivity(), BusyActivity {
@@ -82,24 +86,52 @@ class MainTVActivity : BaseTVActivity(), BusyActivity {
     }
 
     private fun ensureLegacyStoragePermissionsIfNeeded() {
-        if (TVHelper.isSAFSupported(this) || hasLegacyPermissions()) {
+        if (TVHelper.isSAFSupported(this)) {
             return
         }
 
-        val requestPermission = ActivityResultContracts.RequestPermission()
-        val requestPermissionLauncher =
-            registerForActivityResult(requestPermission) { isGranted ->
-                if (!isGranted) {
-                    finish()
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            if (!hasLegacyPermissions()) {
+                val requestPermission = ActivityResultContracts.RequestPermission()
+                val requestPermissionLauncher =
+                    registerForActivityResult(requestPermission) { isGranted ->
+                        if (!isGranted) {
+                            finish()
+                        }
+                    }
+                requestPermissionLauncher.launch(Manifest.permission.READ_EXTERNAL_STORAGE)
+            }
+        }
+        else {
+            if (!hasManageStoragePermissions()) {
+                val manageStorageLauncher = registerForActivityResult(
+                    ActivityResultContracts.StartActivityForResult()
+                ) {
+                    if (!hasManageStoragePermissions()) {
+                        finish()
+                    }
+                }
+
+                try {
+                    val intent = Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION).apply {
+                        data = "package:${packageName}".toUri()
+                    }
+                    manageStorageLauncher.launch(intent)
+                } catch (e: Exception) {
+                    val intent = Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION)
+                    manageStorageLauncher.launch(intent)
                 }
             }
-        requestPermissionLauncher.launch(Manifest.permission.READ_EXTERNAL_STORAGE)
+        }
     }
 
     private fun hasLegacyPermissions(): Boolean {
         val result = ContextCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE)
         return result == PackageManager.PERMISSION_GRANTED
     }
+
+    private fun hasManageStoragePermissions(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
+            && Environment.isExternalStorageManager()
 
     @dagger.Module
     abstract class Module {

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/tv/shared/TVHelper.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/tv/shared/TVHelper.kt
@@ -1,6 +1,7 @@
 package com.swordfish.lemuroid.app.tv.shared
 
 import android.content.Context
+import android.content.Intent
 import android.os.Build
 import android.os.Environment
 
@@ -18,7 +19,13 @@ object TVHelper {
         val isNotLegacyStorage =
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && !Environment.isExternalStorageLegacy()
 
-        return isStandardHardware || isNotLegacyStorage
+        if (!isStandardHardware && !isNotLegacyStorage) {
+            return false;
+        }
+
+        // In Firestick ACTION_OPEN_DOCUMENT_TREE causes ActivityNotFoundException if launched
+        val resolveInfo = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).resolveActivity(packageManager)
+        return resolveInfo != null
     }
 
     fun isTV(context: Context): Boolean {


### PR DESCRIPTION
I have an Amazon Firestick API 30

### Fix inability to choose Game Directory
Lemuroid wrongly assumes that Storage Access Framework is supported on Firestick, and when I try to change Game directory which is None by default, nothing happens. So I added an extra check inside `TVHelper.isSAFSupported` to make it return false if the `ACTION_OPEN_DOCUMENT_TREE` Activity is not found.
However, if `TVHelper.isSAFSupported` is false, Lemuroid falls back to `READ_EXTERNAL_STORAGE` permission which is restricted starting from API 30. I was able to choose the directory in the UI, but Lemuroid can't detect any file inside it. So I had to replace it with `MANAGE_EXTERNAL_STORAGE` permission if Android version is above Android R, which eventually worked. 

### Add ability to play games using the Firestick remote
I also added Firestick TV Remote to the list of supported Controllers following official amazon [documentation](https://developer.amazon.com/docs/fire-tv/identify-controllers.html#is-this-device-a-remote) on how to detect the Remote.
However, the Firestick TV Remote doesn't have a lot of spare buttons that can be remapped, so I chose this configuration.

<img width="756" height="751" alt="image" src="https://github.com/user-attachments/assets/e9585d5e-4a99-4523-beb8-4c1324a90a80" />

The other buttons cannot be remapped. 

After both of these fixes I was able to play games normally on my Firestick ^^

Closes #1123

