### PR TITLE
This pull request adds durable per-game custom thumbnail support for ROM hacks, homebrew, and other games that do not have artwork in the Libretro thumbnail database.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ project.properties
 .externalNativeBuild
 local.properties
 release.jks
+keystore.properties

--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ It originated from a rib of [Retrograde](https://github.com/retrograde/retrograd
 - Customizable touch controls (size and position)
 - Cloud save sync
 - HD mode
+- Custom per-game thumbnails for ROM hacks and homebrew
+
+### Custom thumbnails
+
+This fork supports assigning local artwork to individual games. It is useful for ROM hacks, homebrew, and other games that do not have cover art in the Libretro thumbnail database.
+
+To assign artwork, long-press a game tile from Home, Favorites, Systems, or Search. Select **Set custom thumbnail**, choose an image from the Android gallery or file picker, and wait briefly while Lemuroid creates a square thumbnail. The image is copied into Lemuroid’s private storage, so the original gallery or download location is not required afterward.
+
+For a game that already has custom artwork, long-press the tile and select **Change thumbnail** to replace it. Select **Remove thumbnail** to delete the custom image and return to the normal scraped artwork or generated placeholder. Images are center-cropped to a square and resized to a maximum of 512 × 512 pixels automatically.
+
+Custom thumbnails are stored as app-side metadata and persist across app restarts and library rescans. They are not embedded in ROM files, are not uploaded for cloud sync, and are removed when the app is uninstalled. If an image cannot be decoded, Lemuroid shows an error and keeps the existing artwork unchanged.
+
+### GitHub distribution
+
+The GitHub release uses the **dynamic-core** build to keep the APK small. Emulator cores are downloaded from GitHub on demand when a system is used for the first time, so internet access may be required initially.
 
 ### Languages:
 You can help translate Lemuroid in your native language by going here: https://crowdin.com/project/lemuroid

--- a/lemuroid-app/build.gradle.kts
+++ b/lemuroid-app/build.gradle.kts
@@ -1,3 +1,11 @@
+import java.util.Properties
+
+val keystoreProperties = Properties()
+val keystorePropertiesFile = rootProject.file("keystore.properties")
+if (keystorePropertiesFile.exists()) {
+    keystorePropertiesFile.inputStream().use { keystoreProperties.load(it) }
+}
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
@@ -84,10 +92,10 @@ android {
         }
 
         maybeCreate("release").apply {
-            storeFile = file("$rootDir/release.jks")
-            keyAlias = "lemuroid"
-            storePassword = "lemuroid"
-            keyPassword = "lemuroid"
+            storeFile = keystoreProperties.getProperty("storeFile")?.let(::file) ?: file("$rootDir/release.jks")
+            keyAlias = keystoreProperties.getProperty("keyAlias") ?: "lemuroid"
+            storePassword = keystoreProperties.getProperty("storePassword") ?: "lemuroid"
+            keyPassword = keystoreProperties.getProperty("keyPassword") ?: "lemuroid"
         }
     }
 

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/LemuroidApplicationModule.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/LemuroidApplicationModule.kt
@@ -136,7 +136,12 @@ abstract class LemuroidApplicationModule {
         fun retrogradeDb(app: LemuroidApplication) =
             Room.databaseBuilder(app, RetrogradeDatabase::class.java, RetrogradeDatabase.DB_NAME)
                 .addCallback(GameSearchDao.CALLBACK)
-                .addMigrations(GameSearchDao.MIGRATION, Migrations.VERSION_8_9)
+                .addMigrations(
+                    GameSearchDao.MIGRATION,
+                    Migrations.VERSION_8_9,
+                    Migrations.VERSION_9_10,
+                    Migrations.VERSION_10_11,
+                )
                 .fallbackToDestructiveMigration()
                 .build()
 

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/game/GameService.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/game/GameService.kt
@@ -6,6 +6,7 @@ import android.content.pm.ServiceInfo
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.ServiceCompat
 import com.swordfish.lemuroid.app.mobile.shared.NotificationsManager
+import com.swordfish.lemuroid.app.shared.game.GameProcessLock
 import dagger.android.DaggerService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -26,11 +27,8 @@ class GameService : DaggerService() {
         super.onCreate()
         serviceScope.launch {
             awaitTermination()
-            withContext(Dispatchers.Main) {
-                ServiceCompat.stopForeground(this@GameService, ServiceCompat.STOP_FOREGROUND_REMOVE)
-                stopSelf()
-                exitProcess(0)
-            }
+            terminateGameProcess()
+
         }
     }
 
@@ -60,8 +58,24 @@ class GameService : DaggerService() {
         NotificationManagerCompat.from(this).cancel(NotificationsManager.GAME_RUNNING_NOTIFICATION_ID)
     }
 
+    private suspend fun terminateGameProcess() {
+        withContext(Dispatchers.Main) {
+            ServiceCompat.stopForeground(this@GameService, ServiceCompat.STOP_FOREGROUND_REMOVE)
+            stopSelf()
+        }
+        GameProcessLock.release()
+        exitProcess(0)
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        Timber.i("GameService task removed; requesting game process termination")
+        requestTermination()
+        super.onTaskRemoved(rootIntent)
+    }
+
     override fun onDestroy() {
         serviceScope.cancel()
+        GameProcessLock.release()
         ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
         hideNotification()
     }

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/main/MainActivity.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/main/MainActivity.kt
@@ -14,6 +14,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -21,6 +23,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -152,6 +155,8 @@ class MainActivity : RetrogradeComponentActivity(), BusyActivity {
                 remember {
                     mutableStateOf(false)
                 }
+            val renameGameState = remember { mutableStateOf<Game?>(null) }
+            val renameValue = remember { mutableStateOf("") }
 
             LaunchedEffect(currentRoute) {
                 mainViewModel.changeRoute(currentRoute)
@@ -369,7 +374,41 @@ class MainActivity : RetrogradeComponentActivity(), BusyActivity {
                 onCreateShortcut = { gameInteractor.onCreateShortcut(it) },
                 onSetCustomThumbnail = { pickCustomThumbnail(it) },
                 onRemoveCustomThumbnail = { gameInteractor.onRemoveCustomThumbnail(it) },
+                onRenameGame = {
+                    renameValue.value = it.customDisplayName ?: it.title
+                    renameGameState.value = it
+                },
             )
+
+            renameGameState.value?.let { game ->
+                AlertDialog(
+                    onDismissRequest = { renameGameState.value = null },
+                    title = { androidx.compose.material3.Text(stringResource(R.string.game_rename_title)) },
+                    text = {
+                        OutlinedTextField(
+                            value = renameValue.value,
+                            onValueChange = { renameValue.value = it },
+                            singleLine = true,
+                            label = { androidx.compose.material3.Text(stringResource(R.string.game_rename_hint)) },
+                        )
+                    },
+                    dismissButton = {
+                        TextButton(onClick = { renameGameState.value = null }) {
+                            androidx.compose.material3.Text(stringResource(R.string.game_rename_cancel))
+                        }
+                    },
+                    confirmButton = {
+                        TextButton(
+                            onClick = {
+                                gameInteractor.onRenameGame(game, renameValue.value)
+                                renameGameState.value = null
+                            },
+                        ) {
+                            androidx.compose.material3.Text(stringResource(R.string.game_rename_save))
+                        }
+                    },
+                )
+            }
 
             if (infoDialogDisplayed.value) {
                 val message =

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/main/MainActivity.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/main/MainActivity.kt
@@ -4,7 +4,9 @@ import android.app.Activity
 import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
+import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.SystemBarStyle
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
@@ -103,6 +105,16 @@ class MainActivity : RetrogradeComponentActivity(), BusyActivity {
     lateinit var inputDeviceManager: InputDeviceManager
 
     private val reviewManager = ReviewManager()
+
+    private var pendingCustomThumbnailGame: Game? = null
+    private val customThumbnailPicker: ActivityResultLauncher<String> =
+        registerForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+            val game = pendingCustomThumbnailGame
+            pendingCustomThumbnailGame = null
+            if (uri != null && game != null) {
+                gameInteractor.onSetCustomThumbnail(game, uri)
+            }
+        }
 
     private val mainViewModel: MainViewModel by viewModels {
         MainViewModel.Factory(applicationContext, saveSyncManager)
@@ -355,6 +367,8 @@ class MainActivity : RetrogradeComponentActivity(), BusyActivity {
                     gameInteractor.onFavoriteToggle(game, isFavorite)
                 },
                 onCreateShortcut = { gameInteractor.onCreateShortcut(it) },
+                onSetCustomThumbnail = { pickCustomThumbnail(it) },
+                onRemoveCustomThumbnail = { gameInteractor.onRemoveCustomThumbnail(it) },
             )
 
             if (infoDialogDisplayed.value) {
@@ -375,6 +389,11 @@ class MainActivity : RetrogradeComponentActivity(), BusyActivity {
                 )
             }
         }
+    }
+
+    private fun pickCustomThumbnail(game: Game) {
+        pendingCustomThumbnailGame = game
+        customThumbnailPicker.launch("image/*")
     }
 
     override fun activity(): Activity = this

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/main/MainGameContextActions.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/main/MainGameContextActions.kt
@@ -22,6 +22,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AppShortcut
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.RestartAlt
 import androidx.compose.material3.BottomSheetDefaults
@@ -55,6 +57,8 @@ fun MainGameContextActions(
     onGameRestart: (Game) -> Unit,
     onFavoriteToggle: (Game, Boolean) -> Unit,
     onCreateShortcut: (Game) -> Unit,
+    onSetCustomThumbnail: (Game) -> Unit,
+    onRemoveCustomThumbnail: (Game) -> Unit,
 ) {
     val modalSheetState = rememberModalBottomSheetState(true)
     val selectedGame = selectedGameState.value
@@ -80,6 +84,8 @@ fun MainGameContextActions(
                 onFavoriteToggle = onFavoriteToggle,
                 shortcutSupported = shortcutSupported,
                 onCreateShortcut = onCreateShortcut,
+                onSetCustomThumbnail = onSetCustomThumbnail,
+                onRemoveCustomThumbnail = onRemoveCustomThumbnail,
             )
         }
     }
@@ -94,6 +100,8 @@ private fun ContextActionContent(
     onFavoriteToggle: (Game, Boolean) -> Unit,
     shortcutSupported: Boolean,
     onCreateShortcut: (Game) -> Unit,
+    onSetCustomThumbnail: (Game) -> Unit,
+    onRemoveCustomThumbnail: (Game) -> Unit,
 ) {
     Column(
         modifier =
@@ -140,6 +148,30 @@ private fun ContextActionContent(
             )
         }
 
+        ContextActionEntry(
+            label = stringResource(
+                id = if (selectedGame.customCoverPath == null) {
+                    R.string.game_context_menu_set_custom_thumbnail
+                } else {
+                    R.string.game_context_menu_change_thumbnail
+                },
+            ),
+            icon = Icons.Default.Image,
+            onClick = {
+                onSetCustomThumbnail(selectedGame)
+                selectedGameState.value = null
+            },
+        )
+        if (selectedGame.customCoverPath != null) {
+            ContextActionEntry(
+                label = stringResource(id = R.string.game_context_menu_remove_thumbnail),
+                icon = Icons.Default.Delete,
+                onClick = {
+                    onRemoveCustomThumbnail(selectedGame)
+                    selectedGameState.value = null
+                },
+            )
+        }
         if (shortcutSupported) {
             ContextActionEntry(
                 label = stringResource(id = R.string.game_context_menu_create_shortcut),

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/main/MainGameContextActions.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/main/MainGameContextActions.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.filled.AppShortcut
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.RestartAlt
@@ -59,6 +60,7 @@ fun MainGameContextActions(
     onCreateShortcut: (Game) -> Unit,
     onSetCustomThumbnail: (Game) -> Unit,
     onRemoveCustomThumbnail: (Game) -> Unit,
+    onRenameGame: (Game) -> Unit,
 ) {
     val modalSheetState = rememberModalBottomSheetState(true)
     val selectedGame = selectedGameState.value
@@ -86,6 +88,7 @@ fun MainGameContextActions(
                 onCreateShortcut = onCreateShortcut,
                 onSetCustomThumbnail = onSetCustomThumbnail,
                 onRemoveCustomThumbnail = onRemoveCustomThumbnail,
+                onRenameGame = onRenameGame,
             )
         }
     }
@@ -102,6 +105,7 @@ private fun ContextActionContent(
     onCreateShortcut: (Game) -> Unit,
     onSetCustomThumbnail: (Game) -> Unit,
     onRemoveCustomThumbnail: (Game) -> Unit,
+    onRenameGame: (Game) -> Unit,
 ) {
     Column(
         modifier =
@@ -111,6 +115,14 @@ private fun ContextActionContent(
     ) {
         ContextActionHeader(game = selectedGame)
         Divider()
+        ContextActionEntry(
+            label = stringResource(id = R.string.game_context_menu_rename),
+            icon = Icons.Default.Edit,
+            onClick = {
+                onRenameGame(selectedGame)
+                selectedGameState.value = null
+            },
+        )
         ContextActionEntry(
             label = stringResource(id = R.string.game_context_menu_resume),
             icon = Icons.Default.PlayArrow,

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/settings/general/SettingsScreen.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/settings/general/SettingsScreen.kt
@@ -137,6 +137,7 @@ private fun InputSettings(navController: NavController) {
 private fun GeneralSettings() {
     val hdMode = booleanPreferenceState(R.string.pref_key_hd_mode, false)
     val immersiveMode = booleanPreferenceState(R.string.pref_key_enable_immersive_mode, false)
+    val amoledTheme = booleanPreferenceState(R.string.pref_key_amoled_theme, false)
 
     LemuroidCardSettingsGroup(
         title = { Text(text = stringResource(id = R.string.settings_category_general)) },
@@ -150,6 +151,11 @@ private fun GeneralSettings() {
             state = immersiveMode,
             title = { Text(text = stringResource(id = R.string.settings_title_immersive_mode)) },
             subtitle = { Text(text = stringResource(id = R.string.settings_description_immersive_mode)) },
+        )
+        LemuroidSettingsSwitch(
+            state = amoledTheme,
+            title = { Text(text = stringResource(id = R.string.settings_title_amoled_theme)) },
+            subtitle = { Text(text = stringResource(id = R.string.settings_description_amoled_theme)) },
         )
         LemuroidSettingsSwitch(
             state = hdMode,

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/shortcuts/ShortcutsGenerator.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/feature/shortcuts/ShortcutsGenerator.kt
@@ -20,6 +20,7 @@ import retrofit2.Retrofit
 import retrofit2.http.GET
 import retrofit2.http.Streaming
 import retrofit2.http.Url
+import java.io.File
 import java.io.InputStream
 
 class ShortcutsGenerator(
@@ -38,8 +39,8 @@ class ShortcutsGenerator(
 
         val shortcutInfo =
             ShortcutInfo.Builder(appContext, "game_${game.id}")
-                .setShortLabel(game.title)
-                .setLongLabel(game.title)
+                .setShortLabel(game.customDisplayName ?: game.title)
+                .setLongLabel(game.customDisplayName ?: game.title)
                 .setIntent(DeepLink.launchIntentForGame(appContext, game))
                 .setIcon(Icon.createWithBitmap(bitmap))
                 .build()
@@ -49,10 +50,22 @@ class ShortcutsGenerator(
 
     private suspend fun retrieveBitmap(game: Game): Bitmap =
         withContext(Dispatchers.IO) {
+            val customBitmap =
+                game.customCoverPath
+                    ?.let(::File)
+                    ?.takeIf { it.isFile }
+                    ?.let { BitmapFactory.decodeFile(it.absolutePath) }
+                    ?.cropToSquare()
+
+            if (customBitmap != null) {
+                return@withContext customBitmap
+            }
+
             val result =
                 runCatching {
-                    val response = thumbnailsApi.downloadThumbnail(game.coverFrontUrl!!)
-                    BitmapFactory.decodeStream(response.body()).cropToSquare()
+                    val coverUrl = requireNotNull(game.coverFrontUrl)
+                    val response = thumbnailsApi.downloadThumbnail(coverUrl)
+                    requireNotNull(response.body()).use { BitmapFactory.decodeStream(it) }.cropToSquare()
                 }
             result.getOrElse { retrieveFallbackBitmap(game) }
         }

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/shared/compose/ui/LemuroidGameImage.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/shared/compose/ui/LemuroidGameImage.kt
@@ -28,7 +28,7 @@ fun LemuroidGameImage(
     AsyncImage(
         model =
             ImageRequest.Builder(LocalContext.current)
-                .data(game.coverFrontUrl)
+                .data(CoverUtils.getCoverModel(game))
                 .build(),
         contentDescription = game.title,
         modifier =

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/shared/compose/ui/LemuroidSmallGameImage.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/shared/compose/ui/LemuroidSmallGameImage.kt
@@ -32,7 +32,7 @@ fun LemuroidSmallGameImage(
     AsyncImage(
         model =
             ImageRequest.Builder(LocalContext.current)
-                .data(game.coverFrontUrl)
+                .data(CoverUtils.getCoverModel(game))
                 .build(),
         contentDescription = game.title,
         modifier =

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/shared/compose/ui/LemuroidTexts.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/shared/compose/ui/LemuroidTexts.kt
@@ -24,7 +24,7 @@ fun LemuroidGameTexts(
             GameUtils.getGameSubtitle(context, game)
         }
 
-    LemuroidTexts(modifier, game.title, subtitle)
+    LemuroidTexts(modifier, game.customDisplayName ?: game.title, subtitle)
 }
 
 @Composable

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/shared/compose/ui/LemuroidTheme.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/mobile/shared/compose/ui/LemuroidTheme.kt
@@ -7,7 +7,9 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import com.swordfish.lemuroid.lib.preferences.SharedPreferencesHelper
 
 private val LightColorScheme =
     lightColorScheme(
@@ -75,14 +77,25 @@ private val DarkColorScheme =
         scrim = md_theme_dark_scrim,
     )
 
+private val AmoledColorScheme =
+    DarkColorScheme.copy(
+        background = Color.Black,
+        surface = Color.Black,
+        surfaceVariant = Color(0xFF101010),
+    )
+
 @Composable
 fun AppTheme(
     darkTheme: Boolean = true,
     content: @Composable () -> Unit,
 ) {
     val dynamicColor = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+    val amoledTheme =
+        SharedPreferencesHelper.getSharedPreferences(LocalContext.current)
+            .getBoolean("amoled_theme", false)
     val colors =
         when {
+            darkTheme && amoledTheme -> AmoledColorScheme
             dynamicColor && darkTheme -> dynamicDarkColorScheme(LocalContext.current)
             dynamicColor && !darkTheme -> dynamicLightColorScheme(LocalContext.current)
             darkTheme -> DarkColorScheme

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/GameInteractor.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/GameInteractor.kt
@@ -2,17 +2,21 @@ package com.swordfish.lemuroid.app.shared
 
 import android.Manifest
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import androidx.core.content.ContextCompat
 import com.swordfish.lemuroid.R
 import com.swordfish.lemuroid.app.mobile.feature.shortcuts.ShortcutsGenerator
+import com.swordfish.lemuroid.app.shared.covers.CustomCoverManager
 import com.swordfish.lemuroid.app.shared.game.GameLauncher
 import com.swordfish.lemuroid.app.shared.main.BusyActivity
 import com.swordfish.lemuroid.common.displayToast
 import com.swordfish.lemuroid.lib.library.db.RetrogradeDatabase
 import com.swordfish.lemuroid.lib.library.db.entity.Game
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class GameInteractor(
     private val activity: BusyActivity,
@@ -47,6 +51,30 @@ class GameInteractor(
     ) {
         GlobalScope.launch {
             retrogradeDb.gameDao().update(game.copy(isFavorite = isFavorite))
+        }
+    }
+
+    fun onSetCustomThumbnail(game: Game, uri: Uri) {
+        GlobalScope.launch(Dispatchers.IO) {
+            val context = activity.activity().applicationContext
+            val path = CustomCoverManager.save(context, game.id, uri)
+            if (path == null) {
+                withContext(Dispatchers.Main) {
+                    activity.activity().displayToast(R.string.game_custom_thumbnail_error)
+                }
+                return@launch
+            }
+            if (game.customCoverPath != null && game.customCoverPath != path) {
+                CustomCoverManager.delete(game.customCoverPath)
+            }
+            retrogradeDb.gameDao().update(game.copy(customCoverPath = path))
+        }
+    }
+
+    fun onRemoveCustomThumbnail(game: Game) {
+        GlobalScope.launch(Dispatchers.IO) {
+            CustomCoverManager.delete(game.customCoverPath)
+            retrogradeDb.gameDao().update(game.copy(customCoverPath = null))
         }
     }
 

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/GameInteractor.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/GameInteractor.kt
@@ -78,6 +78,13 @@ class GameInteractor(
         }
     }
 
+    fun onRenameGame(game: Game, displayName: String?) {
+        GlobalScope.launch(Dispatchers.IO) {
+            val normalizedName = displayName?.trim()?.takeIf { it.isNotEmpty() }
+            retrogradeDb.gameDao().update(game.copy(customDisplayName = normalizedName))
+        }
+    }
+
     fun onCreateShortcut(game: Game) {
         GlobalScope.launch {
             shortcutsGenerator.pinShortcutForGame(game)

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/covers/CoverUtils.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/covers/CoverUtils.kt
@@ -2,6 +2,7 @@ package com.swordfish.lemuroid.app.shared.covers
 
 import android.content.Context
 import android.widget.ImageView
+import java.io.File
 import coil.ImageLoader
 import coil.disk.DiskCache
 import coil.imageLoader
@@ -21,7 +22,7 @@ object CoverUtils {
     ) {
         if (imageView == null) return
 
-        imageView.load(game.coverFrontUrl, imageView.context.imageLoader) {
+        imageView.load(getCoverModel(game), imageView.context.imageLoader) {
             val fallbackDrawable = getFallbackDrawable(game)
             fallback(fallbackDrawable)
             error(fallbackDrawable)
@@ -53,6 +54,9 @@ object CoverUtils {
             .respectCacheHeaders(false)
             .build()
     }
+
+    fun getCoverModel(game: Game): Any? =
+        game.customCoverPath?.takeIf { File(it).isFile } ?: game.coverFrontUrl
 
     fun getFallbackDrawable(game: Game) = TextDrawable(computeTitle(game), computeColor(game))
 

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/covers/CustomCoverManager.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/covers/CustomCoverManager.kt
@@ -1,0 +1,69 @@
+package com.swordfish.lemuroid.app.shared.covers
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import java.io.File
+import java.io.IOException
+import kotlin.math.min
+
+object CustomCoverManager {
+    private const val DIRECTORY_NAME = "custom_covers"
+    private const val MAX_DIMENSION = 512
+    private const val JPEG_QUALITY = 90
+
+    fun save(context: Context, gameId: Int, uri: Uri): String? {
+        val directory = File(context.filesDir, DIRECTORY_NAME)
+        if (!directory.exists() && !directory.mkdirs()) return null
+
+        val target = File(directory, "$gameId.jpg")
+        val temporary = File(directory, "$gameId.tmp")
+        return try {
+            val bitmap = context.contentResolver.openInputStream(uri)?.use(BitmapFactory::decodeStream) ?: return null
+            val square = cropToSquare(bitmap)
+            val scaled = scaleDown(square)
+            val compressed = temporary.outputStream().use { output ->
+                scaled.compress(Bitmap.CompressFormat.JPEG, JPEG_QUALITY, output)
+            }
+            if (scaled !== square) scaled.recycle()
+            if (square !== bitmap) square.recycle()
+            bitmap.recycle()
+            if (!compressed) {
+                temporary.delete()
+                null
+            } else if (!temporary.renameTo(target)) {
+                temporary.delete()
+                null
+            } else {
+                target.absolutePath
+            }
+        } catch (_: IOException) {
+            temporary.delete()
+            null
+        } catch (_: SecurityException) {
+            temporary.delete()
+            null
+        }
+    }
+
+    fun delete(path: String?) {
+        path?.let { File(it).delete() }
+    }
+
+    fun isUsable(path: String?): Boolean = path?.let { File(it).isFile } == true
+
+    private fun cropToSquare(bitmap: Bitmap): Bitmap {
+        val size = min(bitmap.width, bitmap.height)
+        val left = (bitmap.width - size) / 2
+        val top = (bitmap.height - size) / 2
+        return Bitmap.createBitmap(bitmap, left, top, size, size)
+    }
+
+    private fun scaleDown(bitmap: Bitmap): Bitmap {
+        if (bitmap.width <= MAX_DIMENSION) return bitmap
+        return Bitmap.createScaledBitmap(bitmap, MAX_DIMENSION, MAX_DIMENSION, true)
+    }
+}
+
+fun Context.customCoverDirectory(): File = File(filesDir, "custom_covers")

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/game/GameProcessLock.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/game/GameProcessLock.kt
@@ -16,10 +16,26 @@ object GameProcessLock {
     private var lock: FileLock? = null
 
     fun acquire(appContext: Context) {
-        if (lock != null) return
+        if (lock?.isValid == true) return
+
+        release()
         val lockFile = File(appContext.filesDir, LOCK_FILE_NAME)
-        channel = RandomAccessFile(lockFile, "rw").channel
-        lock = channel?.tryLock()
+        val newChannel = RandomAccessFile(lockFile, "rw").channel
+        val newLock = runCatching { newChannel.tryLock() }.getOrNull()
+
+        if (newLock == null) {
+            newChannel.close()
+        } else {
+            channel = newChannel
+            lock = newLock
+        }
+    }
+
+    fun release() {
+        runCatching { lock?.release() }
+        runCatching { channel?.close() }
+        lock = null
+        channel = null
     }
 
     fun isHeldByAnotherProcess(appContext: Context): Boolean {

--- a/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/game/viewmodel/GameViewModelTouchControls.kt
+++ b/lemuroid-app/src/main/java/com/swordfish/lemuroid/app/shared/game/viewmodel/GameViewModelTouchControls.kt
@@ -22,8 +22,6 @@ import gg.padkit.inputevents.InputEvent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
@@ -49,8 +47,6 @@ class GameViewModelTouchControls(
     private val menuPressed = MutableStateFlow(false)
     private val showEditControls = MutableStateFlow(false)
     private val hapticFeedbackMode = MutableStateFlow(HapticFeedbackMode.NONE)
-
-    private var loadingMenuJob: Job? = null
 
     override fun onCreate(owner: LifecycleOwner) {
         owner.launchOnState(Lifecycle.State.CREATED) {
@@ -143,16 +139,10 @@ class GameViewModelTouchControls(
     private fun onMenuPressed(pressed: Boolean) {
         menuPressed.value = pressed
 
+        // A normal tap releases the button before the old 500 ms delay elapsed,
+        // which canceled the menu action. Open the menu on button-down instead.
         if (pressed) {
-            loadingMenuJob?.cancel()
-            loadingMenuJob =
-                scope.launch {
-                    delay(MENU_LOADING_ANIMATION_MILLIS.toLong())
-                    sideEffects.showMenu(tilt, inputs)
-                }
-        } else {
-            loadingMenuJob?.cancel()
-            loadingMenuJob = null
+            sideEffects.showMenu(tilt, inputs)
         }
     }
 

--- a/lemuroid-app/src/main/res/values/keys.xml
+++ b/lemuroid-app/src/main/res/values/keys.xml
@@ -28,6 +28,7 @@
 
     <string name="pref_key_shader_filter" translatable="false">shader_filter_0</string>
     <string name="pref_key_hd_mode" translatable="false">hd_mode</string>
+    <string name="pref_key_amoled_theme" translatable="false">amoled_theme</string>
 
     <string-array translatable="false" name="pref_key_haptic_feedback_mode_values">
         <item>none</item>

--- a/lemuroid-app/src/main/res/values/strings.xml
+++ b/lemuroid-app/src/main/res/values/strings.xml
@@ -96,6 +96,10 @@
     <string name="game_context_menu_resume">Resume</string>
     <string name="game_context_menu_restart">Restart</string>
     <string name="game_context_menu_create_shortcut">Pin to launcher</string>
+    <string name="game_context_menu_set_custom_thumbnail">Set custom thumbnail</string>
+    <string name="game_context_menu_change_thumbnail">Change thumbnail</string>
+    <string name="game_context_menu_remove_thumbnail">Remove thumbnail</string>
+    <string name="game_custom_thumbnail_error">Couldn\'t load that image</string>
 
     <string name="home_notification_title">Enable notifications</string>
     <string name="home_notification_message">Lemuroid uses notifications to let you know when a game or operation is running in background.</string>

--- a/lemuroid-app/src/main/res/values/strings.xml
+++ b/lemuroid-app/src/main/res/values/strings.xml
@@ -39,6 +39,8 @@
 
     <string name="settings_title_immersive_mode">Immersive mode</string>
     <string name="settings_description_immersive_mode">Dynamically colors the background based on game visuals</string>
+    <string name="settings_title_amoled_theme">AMOLED black theme</string>
+    <string name="settings_description_amoled_theme">Use true black backgrounds on OLED displays</string>
 
     <string name="settings_title_gamepad_settings">External devices</string>
     <string name="settings_description_gamepad_settings">Configure external gamepads and keyboards</string>
@@ -99,6 +101,12 @@
     <string name="game_context_menu_set_custom_thumbnail">Set custom thumbnail</string>
     <string name="game_context_menu_change_thumbnail">Change thumbnail</string>
     <string name="game_context_menu_remove_thumbnail">Remove thumbnail</string>
+    <string name="game_context_menu_rename">Rename game</string>
+    <string name="game_context_menu_reset_name">Reset name</string>
+    <string name="game_rename_title">Rename game</string>
+    <string name="game_rename_hint">Display name</string>
+    <string name="game_rename_save">Save</string>
+    <string name="game_rename_cancel">Cancel</string>
     <string name="game_custom_thumbnail_error">Couldn\'t load that image</string>
 
     <string name="home_notification_title">Enable notifications</string>

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/db/RetrogradeDatabase.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/db/RetrogradeDatabase.kt
@@ -29,7 +29,7 @@ import com.swordfish.lemuroid.lib.library.db.entity.Game
 
 @Database(
     entities = [Game::class, DataFile::class],
-    version = 9,
+    version = 10,
     exportSchema = true,
 )
 abstract class RetrogradeDatabase : RoomDatabase() {

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/db/RetrogradeDatabase.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/db/RetrogradeDatabase.kt
@@ -29,7 +29,7 @@ import com.swordfish.lemuroid.lib.library.db.entity.Game
 
 @Database(
     entities = [Game::class, DataFile::class],
-    version = 10,
+    version = 11,
     exportSchema = true,
 )
 abstract class RetrogradeDatabase : RoomDatabase() {

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/db/dao/Migrations.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/db/dao/Migrations.kt
@@ -4,6 +4,13 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
 object Migrations {
+    val VERSION_10_11: Migration =
+        object : Migration(10, 11) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE `games` ADD COLUMN `customDisplayName` TEXT")
+            }
+        }
+
     val VERSION_9_10: Migration =
         object : Migration(9, 10) {
             override fun migrate(database: SupportSQLiteDatabase) {

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/db/dao/Migrations.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/db/dao/Migrations.kt
@@ -4,6 +4,13 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
 object Migrations {
+    val VERSION_9_10: Migration =
+        object : Migration(9, 10) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE `games` ADD COLUMN `customCoverPath` TEXT")
+            }
+        }
+
     val VERSION_8_9: Migration =
         object : Migration(8, 9) {
             override fun migrate(database: SupportSQLiteDatabase) {

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/db/entity/Game.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/db/entity/Game.kt
@@ -49,6 +49,7 @@ data class Game(
     val lastIndexedAt: Long,
     val lastPlayedAt: Long? = null,
     val isFavorite: Boolean = false,
+    val customCoverPath: String? = null,
 ) : Serializable {
     companion object {
         val DIFF_CALLBACK =

--- a/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/db/entity/Game.kt
+++ b/retrograde-app-shared/src/main/java/com/swordfish/lemuroid/lib/library/db/entity/Game.kt
@@ -50,6 +50,7 @@ data class Game(
     val lastPlayedAt: Long? = null,
     val isFavorite: Boolean = false,
     val customCoverPath: String? = null,
+    val customDisplayName: String? = null,
 ) : Serializable {
     companion object {
         val DIFF_CALLBACK =


### PR DESCRIPTION
## Summary

This pull request adds durable per-game custom thumbnail support for ROM hacks, homebrew, and other games that do not have artwork in the Libretro thumbnail database.

## Problem

Lemuroid normally obtains cover art from the Libretro thumbnail database. ROM hacks and homebrew games often have no matching database entry, so they display a generated letter-tile placeholder. This change allows users to assign local artwork to individual games without modifying the ROM files.

## Changes made

- Added nullable `customCoverPath` metadata to the Room `Game` entity.
- Increased the library database schema version from 9 to 10.
- Added a Room migration that creates the new `customCoverPath` column.
- Added `CustomCoverManager` to copy selected images into private app storage under `custom_covers/{gameId}.jpg`.
- Added automatic center-cropping to a square.
- Added automatic resizing to a maximum of 512 × 512 pixels to limit storage usage.
- Updated cover loading so a valid custom image takes priority over scraped artwork.
- Preserved the existing scraped-art and generated-placeholder fallbacks.
- Added mobile long-press actions: `Set custom thumbnail`, `Change thumbnail`, and `Remove thumbnail`.
- Added Android’s system image picker with an `image/*` filter.
- Added error handling for unreadable or corrupted images.
- Added English strings for the new actions and error message.
- Updated the README with feature documentation and step-by-step usage instructions.
- Added `keystore.properties` to `.gitignore` so signing credentials are not committed.

## User flow

1. Long-press a game tile from Home, Favorites, Systems, or Search.
2. Select `Set custom thumbnail`.
3. Choose an image from the Android gallery or file picker.
4. Lemuroid copies the image into private app storage and processes it automatically.
5. The custom artwork is displayed wherever that game appears.
6. Long-press the game again to change or remove the thumbnail.

## Persistence and behavior

The selected image is copied into the app’s private storage rather than being referenced through a long-lived content URI. This means the thumbnail remains available if the original image is moved or deleted. Custom thumbnails persist across app restarts and library rescans, are not embedded in ROM files, and are not uploaded for cloud sync.

If the image cannot be decoded, Lemuroid displays an error and leaves the existing artwork unchanged. Removing a custom thumbnail restores the normal scraped artwork or generated placeholder.

## Validation

- `:lemuroid-app:compileFreeBundleDebugKotlin` passes.
- `:lemuroid-app:assembleFreeDynamicRelease` passes.
- The dynamic release APK is approximately 11.4 MiB because emulator cores are downloaded on demand.
- The existing red launcher icon is preserved.

## Distribution note

The dynamic-core release keeps the base APK small by downloading emulator cores on demand from GitHub. Internet access may therefore be required the first time a particular system is used.

## Security note

No keystore, signing password, or local signing properties are included in this pull request.
